### PR TITLE
feat(tools): add URL encode/decode tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="base64">Base64</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="color">Color</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="notes">Notes</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="url">URL</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -78,6 +79,9 @@
         </button>
         <button class="tab" role="tab" aria-selected="false" aria-controls="panel-notes" id="tab-notes" data-panel="notes" tabindex="-1">
           <span class="tab__icon" aria-hidden="true">📝</span> Notes
+        </button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="panel-url" id="tab-url" data-panel="url" tabindex="-1">
+          <span class="tab__icon" aria-hidden="true">%</span> URL
         </button>
       </div>
     </div>
@@ -354,6 +358,64 @@
               <span class="notes__count" id="notesCount" aria-live="polite">0 notes</span>
             </div>
             <ul class="notes__list" id="notesList" role="list" aria-label="Notes list"></ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════════════════════════
+           URL Encoder / Decoder
+           ═══════════════════════════════ -->
+      <section
+        id="panel-url"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-url"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">URL Encoder / Decoder</h2>
+              <p class="tool__desc">Encode text for use in URLs or decode percent-encoded strings back to plain text.</p>
+            </div>
+          </div>
+          <div class="tool__body tool__body--split">
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Input</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm" id="urlEncode">Encode →</button>
+                  <button class="btn btn--sm btn--secondary" id="urlDecode">← Decode</button>
+                  <button class="btn btn--sm btn--ghost" id="urlClear">Clear</button>
+                </div>
+              </div>
+              <textarea
+                class="code-area"
+                id="urlInput"
+                placeholder="Enter plain text to encode, or a percent-encoded URL to decode…"
+                spellcheck="false"
+                autocomplete="off"
+                aria-label="URL input"
+              ></textarea>
+              <div class="status-bar" id="urlStatus" aria-live="polite" role="status"></div>
+            </div>
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Output</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="urlCopy" disabled>Copy</button>
+                  <button class="btn btn--sm btn--ghost" id="urlSwap" title="Swap input ↔ output">⇄ Swap</button>
+                </div>
+              </div>
+              <textarea
+                class="code-area"
+                id="urlOutput"
+                placeholder="Result will appear here…"
+                readonly
+                spellcheck="false"
+                aria-label="URL output"
+              ></textarea>
+            </div>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -631,3 +631,56 @@ notesForm.addEventListener('submit', (e) => {
 
 loadNotes();
 renderNotes();
+
+/* ============================================
+   URL Encoder / Decoder
+   ============================================ */
+const urlInput  = document.getElementById('urlInput');
+const urlOutput = document.getElementById('urlOutput');
+const urlStatus = document.getElementById('urlStatus');
+const urlCopy   = document.getElementById('urlCopy');
+
+function setUrlStatus(msg, type = '') {
+  urlStatus.textContent = msg;
+  urlStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
+}
+
+document.getElementById('urlEncode').addEventListener('click', () => {
+  const text = urlInput.value;
+  if (!text) { setUrlStatus('Nothing to encode.', 'error'); return; }
+  const encoded = encodeURIComponent(text);
+  urlOutput.value = encoded;
+  urlCopy.disabled = false;
+  setUrlStatus(`Encoded · ${text.length} chars → ${encoded.length} chars`, 'ok');
+});
+
+document.getElementById('urlDecode').addEventListener('click', () => {
+  const text = urlInput.value.trim();
+  if (!text) { setUrlStatus('Nothing to decode.', 'error'); return; }
+  try {
+    const decoded = decodeURIComponent(text);
+    urlOutput.value = decoded;
+    urlCopy.disabled = false;
+    setUrlStatus(`Decoded · ${text.length} chars → ${decoded.length} chars`, 'ok');
+  } catch {
+    setUrlStatus('Malformed percent-encoding — cannot decode.', 'error');
+  }
+});
+
+document.getElementById('urlClear').addEventListener('click', () => {
+  urlInput.value = '';
+  urlOutput.value = '';
+  urlCopy.disabled = true;
+  setUrlStatus('');
+  urlInput.focus();
+});
+
+urlCopy.addEventListener('click', () => copyText(urlOutput.value, urlCopy));
+
+document.getElementById('urlSwap').addEventListener('click', () => {
+  const tmp = urlInput.value;
+  urlInput.value = urlOutput.value;
+  urlOutput.value = tmp;
+  urlCopy.disabled = !urlOutput.value;
+  setUrlStatus('Swapped.');
+});


### PR DESCRIPTION
Closes #15

## Changes
- Added URL tab button to the tablist (6th tab, `%` icon)
- Added URL nav link in mobile hamburger menu
- Added `#panel-url` section: input textarea, Encode/Decode/Clear buttons, output textarea (readonly), Copy + Swap buttons, status bar
- Added JS: `encodeURIComponent` for encoding, `decodeURIComponent` with try/catch for decoding (shows "Malformed percent-encoding" error on invalid input)
- Swap button chains operations (output → input)
- Status bar shows char counts in/out

## Architecture
Stacked on `alpha/issue-6` (PR #10) — this is tab 6 alongside the existing 5. Reuses all existing CSS classes (`.tool`, `.tool__body--split`, `.pane__header`, `.btn`, `.code-area`, `.status-bar`) with zero new styles needed.

## Test Plan
- [ ] Encode `hello world` → `hello%20world`
- [ ] Encode `https://example.com/path?q=a&b=c` → properly encoded string
- [ ] Decode `hello%20world` → `hello world`
- [ ] Decode malformed `%ZZ` → error shown in status bar, output unchanged
- [ ] Copy button copies output to clipboard
- [ ] Swap moves output back to input for chaining
- [ ] Tab accessible via keyboard arrow keys
- [ ] Mobile nav "URL" link jumps to and activates the URL tab