### PR TITLE
fix(notes): filter by note ID to prevent stale-index bug on rapid delete

### DIFF
--- a/script.js
+++ b/script.js
@@ -647,9 +647,10 @@ function renderNotes() {
     return;
   }
 
-  notes.forEach((note, index) => {
+  notes.forEach((note) => {
     const li = document.createElement('li');
     li.className = 'note-item';
+    li.dataset.id = note.id;
 
     const text = document.createElement('span');
     text.className = 'note-item__text';
@@ -660,7 +661,7 @@ function renderNotes() {
     del.setAttribute('aria-label', `Delete note: ${note.text}`);
     del.setAttribute('type', 'button');
     del.textContent = '×';
-    del.addEventListener('click', () => deleteNote(index));
+    del.addEventListener('click', () => deleteNote(note.id));
 
     li.appendChild(text);
     li.appendChild(del);
@@ -679,16 +680,15 @@ function addNote(text) {
   renderNotes();
 }
 
-function deleteNote(index) {
-  const items = notesList.querySelectorAll('.note-item');
-  const li = items[index];
+function deleteNote(id) {
+  const li = notesList.querySelector(`.note-item[data-id="${id}"]`);
   if (li) {
     li.style.transition = 'opacity 150ms ease, transform 150ms ease';
     li.style.opacity = '0';
     li.style.transform = 'translateX(10px)';
   }
   setTimeout(() => {
-    notes.splice(index, 1);
+    notes = notes.filter(n => n.id !== id);
     saveNotes();
     renderNotes();
   }, 150);


### PR DESCRIPTION
Closes #13

## Problem
`deleteNote(index)` used the array index captured at render time. When two notes were deleted rapidly (before the 150ms fade animation completed), the second delete would `splice` the wrong element — the index was stale because the first deletion had already shifted the array.

## Changes
- `renderNotes`: store `data-id` on each `<li>`, pass `note.id` (not `index`) to click handler
- `deleteNote(id)`: look up `<li>` via `[data-id]` selector for animation, then use `notes.filter(n => n.id !== id)` to remove by identity

Notes already have `id: Date.now()` from `addNote()`, so no schema change needed.

## Test Plan
1. Add 3+ notes
2. Click delete on two notes rapidly (before first animation finishes)
3. Verify exactly those two notes are removed, not adjacent ones
4. Check console — no errors

## Evidence
Single-file change, logic replaces index-based splice with identity-based filter. Race condition eliminated.