### PR TITLE
fix(a11y): color-contrast and link-in-text-block failures

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,7 @@
 :root {
   --color-bg: #f0f2f5;
   --color-text: #1a1d23;
-  --color-text-muted: #6b7280;
+  --color-text-muted: #4b5563;
   --color-primary: #4f46e5;
   --color-primary-hover: #4338ca;
   --color-surface: #ffffff;
@@ -550,17 +550,17 @@ main {
 
 /* JSON syntax highlight colors */
 .json-key  { color: #7c3aed; }
-.json-str  { color: #16a34a; }
+.json-str  { color: #15803d; }
 .json-num  { color: #b45309; }
 .json-bool { color: #0e7490; }
-.json-null { color: #9ca3af; }
+.json-null { color: #52525b; }
 .json-error { color: var(--color-danger); }
 
 [data-theme="dark"] .json-key  { color: #c4b5fd; }
 [data-theme="dark"] .json-str  { color: #6ee7b7; }
 [data-theme="dark"] .json-num  { color: #fbbf24; }
 [data-theme="dark"] .json-bool { color: #67e8f9; }
-[data-theme="dark"] .json-null { color: #6b7280; }
+[data-theme="dark"] .json-null { color: #9ca3af; }
 
 /* ============================================
    Status bar
@@ -993,9 +993,10 @@ main {
 
 .about a {
   color: var(--color-primary);
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
-.about a:hover { text-decoration: underline; }
+.about a:hover { text-decoration-style: double; }
 
 .about__meta { font-size: 0.82rem; }
 


### PR DESCRIPTION
Closes #22

## Changes

**color-contrast** — all combinations now meet WCAG AA (4.5:1 normal text):

| Element | Before | After | Ratio before | Ratio after |
|---|---|---|---|---|
| `--color-text-muted` (light) | `#6b7280` | `#4b5563` | 4.30:1 ❌ | 6.74:1 ✅ |
| `.json-str` (light) | `#16a34a` | `#15803d` | 2.94:1 ❌ | 4.54:1 ✅ |
| `.json-null` (light) | `#9ca3af` | `#52525b` | 2.26:1 ❌ | 6.99:1 ✅ |
| `.json-null` (dark) | `#6b7280` | `#9ca3af` | 3.96:1 ❌ | 7.50:1 ✅ |

**link-in-text-block** — `.about a` now always shows an underline (`text-underline-offset: 2px`). Hover changes to double underline for visual feedback. Links are no longer identified by color alone.

## Approach

Pure CSS — no JS or HTML changes. The `--color-text-muted` fix cascades to all elements using that variable (nav links, tool descriptions, pane labels, status bar, etc.). JSON syntax highlight colors are fixed independently since they have hardcoded values.

## Test Plan

- [ ] Verify light theme: muted text, JSON string/null values are clearly readable
- [ ] Verify dark theme: JSON null is clearly readable
- [ ] Confirm `.about a` link shows underline by default
- [ ] Run Lighthouse CI after merge — accessibility score should reach ≥ 0.9