### PR TITLE
feat(bookmarks): add URL bookmarks widget with favicon and localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="color">Color</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="notes">Notes</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="url">URL</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="bookmarks">Bookmarks</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -82,6 +83,9 @@
         </button>
         <button class="tab" role="tab" aria-selected="false" aria-controls="panel-url" id="tab-url" data-panel="url" tabindex="-1">
           <span class="tab__icon" aria-hidden="true">%</span> URL
+        </button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="panel-bookmarks" id="tab-bookmarks" data-panel="bookmarks" tabindex="-1">
+          <span class="tab__icon" aria-hidden="true">🔖</span> Bookmarks
         </button>
       </div>
     </div>
@@ -416,6 +420,58 @@
                 aria-label="URL output"
               ></textarea>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════════════════════════
+           Bookmarks
+           ═══════════════════════════════ -->
+      <section
+        id="panel-bookmarks"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-bookmarks"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">Bookmarks</h2>
+              <p class="tool__desc">Save URLs for quick access. Bookmarks persist in your browser's local storage.</p>
+            </div>
+          </div>
+          <div class="tool__body">
+            <form class="bookmarks__form" id="bookmarksForm" aria-label="Add a bookmark">
+              <div class="bookmarks__form-row">
+                <label for="bookmarkUrl" class="sr-only">URL</label>
+                <input
+                  type="text"
+                  id="bookmarkUrl"
+                  class="bookmarks__input"
+                  placeholder="https://example.com"
+                  spellcheck="false"
+                  autocomplete="off"
+                  inputmode="url"
+                  required
+                >
+                <label for="bookmarkLabel" class="sr-only">Label (optional)</label>
+                <input
+                  type="text"
+                  id="bookmarkLabel"
+                  class="bookmarks__input bookmarks__input--label"
+                  placeholder="Label (optional)"
+                  maxlength="80"
+                  autocomplete="off"
+                >
+                <button type="submit" class="btn">Add</button>
+              </div>
+            </form>
+            <div class="status-bar" id="bookmarkStatus" aria-live="polite" role="status"></div>
+            <div class="notes-meta">
+              <span class="notes__count" id="bookmarksCount" aria-live="polite">0 bookmarks</span>
+            </div>
+            <ul class="bookmarks__list" id="bookmarksList" role="list" aria-label="Bookmarks list"></ul>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -12,3 +12,4 @@ import './tools/base64.js';
 import './tools/color.js';
 import './tools/notes.js';
 import './tools/url.js';
+import './tools/bookmarks.js';

--- a/styles.css
+++ b/styles.css
@@ -962,6 +962,142 @@ main {
 }
 
 /* ============================================
+   Bookmarks tool
+   ============================================ */
+.bookmarks__form {
+  margin-bottom: 0.5rem;
+}
+
+.bookmarks__form-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.bookmarks__input {
+  flex: 1 1 200px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: var(--font-main);
+  transition: border-color var(--transition), box-shadow var(--transition), background var(--transition-slow), color var(--transition-slow);
+}
+.bookmarks__input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+.bookmarks__input--label {
+  flex: 0 1 160px;
+}
+.bookmarks__input::placeholder { color: var(--color-text-muted); }
+
+.bookmarks__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+.bookmarks__list::-webkit-scrollbar { width: 4px; }
+.bookmarks__list::-webkit-scrollbar-track { background: transparent; }
+.bookmarks__list::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 2px; }
+
+.bookmark-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  animation: noteIn 200ms ease forwards;
+  transition: background var(--transition-slow), border-color var(--transition-slow);
+}
+
+.bookmark-item__favicon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  object-fit: contain;
+}
+
+.bookmark-item__favicon--fallback {
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.bookmark-item__info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.bookmark-item__link {
+  font-size: 0.9rem;
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color var(--transition);
+}
+.bookmark-item__link:hover { color: var(--color-primary-hover); }
+
+.bookmark-item__url {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bookmark-item__delete {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background var(--transition), color var(--transition), opacity var(--transition);
+  opacity: 0;
+}
+.bookmark-item:hover .bookmark-item__delete,
+.bookmark-item:focus-within .bookmark-item__delete { opacity: 1; }
+.bookmark-item__delete:hover {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--color-danger);
+}
+.bookmark-item__delete:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--color-danger);
+  outline-offset: 2px;
+}
+
+.bookmark-empty {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  padding: 1.5rem;
+}
+
+/* ============================================
    About section
    ============================================ */
 .about {

--- a/tools/bookmarks.js
+++ b/tools/bookmarks.js
@@ -1,0 +1,159 @@
+// Bookmarks
+
+const bookmarksForm  = document.getElementById('bookmarksForm');
+const bookmarkUrl    = document.getElementById('bookmarkUrl');
+const bookmarkLabel  = document.getElementById('bookmarkLabel');
+const bookmarksList  = document.getElementById('bookmarksList');
+const bookmarksCount = document.getElementById('bookmarksCount');
+const bookmarkStatus = document.getElementById('bookmarkStatus');
+const BOOKMARKS_KEY  = 'peer-bookmarks';
+
+let bookmarks = [];
+
+function loadBookmarks() {
+  try { bookmarks = JSON.parse(localStorage.getItem(BOOKMARKS_KEY)) || []; }
+  catch { bookmarks = []; }
+}
+
+function saveBookmarks() {
+  localStorage.setItem(BOOKMARKS_KEY, JSON.stringify(bookmarks));
+}
+
+function faviconUrl(url) {
+  try {
+    const domain = new URL(url).hostname;
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=16`;
+  } catch {
+    return '';
+  }
+}
+
+function renderBookmarks() {
+  bookmarksList.innerHTML = '';
+
+  if (bookmarks.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'bookmark-empty';
+    empty.textContent = 'No bookmarks yet. Add a URL above.';
+    bookmarksList.appendChild(empty);
+    bookmarksCount.textContent = '0 bookmarks';
+    return;
+  }
+
+  bookmarks.forEach((bm) => {
+    const li = document.createElement('li');
+    li.className = 'bookmark-item';
+    li.dataset.id = bm.id;
+
+    const favicon = document.createElement('img');
+    favicon.className = 'bookmark-item__favicon';
+    favicon.width = 16;
+    favicon.height = 16;
+    favicon.alt = '';
+    favicon.setAttribute('aria-hidden', 'true');
+    const src = faviconUrl(bm.url);
+    if (src) {
+      favicon.src = src;
+      favicon.onerror = () => { favicon.replaceWith(makeFaviconFallback()); };
+    } else {
+      favicon.replaceWith(makeFaviconFallback());
+    }
+
+    const link = document.createElement('a');
+    link.className = 'bookmark-item__link';
+    link.href = bm.url;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = bm.label || bm.url;
+    link.title = bm.url;
+
+    const urlSpan = document.createElement('span');
+    urlSpan.className = 'bookmark-item__url';
+    urlSpan.textContent = bm.url;
+
+    const info = document.createElement('div');
+    info.className = 'bookmark-item__info';
+    info.appendChild(link);
+    if (bm.label) info.appendChild(urlSpan);
+
+    const del = document.createElement('button');
+    del.className = 'bookmark-item__delete';
+    del.setAttribute('aria-label', `Delete bookmark: ${bm.label || bm.url}`);
+    del.setAttribute('type', 'button');
+    del.textContent = '×';
+    del.addEventListener('click', () => deleteBookmark(bm.id));
+
+    li.appendChild(favicon);
+    li.appendChild(info);
+    li.appendChild(del);
+    bookmarksList.appendChild(li);
+  });
+
+  const count = bookmarks.length;
+  bookmarksCount.textContent = `${count} ${count === 1 ? 'bookmark' : 'bookmarks'}`;
+}
+
+function makeFaviconFallback() {
+  const span = document.createElement('span');
+  span.className = 'bookmark-item__favicon bookmark-item__favicon--fallback';
+  span.setAttribute('aria-hidden', 'true');
+  span.textContent = '🔖';
+  return span;
+}
+
+function normalizeUrl(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return 'https://' + trimmed;
+}
+
+function addBookmark(rawUrl, label) {
+  const url = normalizeUrl(rawUrl);
+  if (!url) return;
+
+  // Basic URL validation
+  try { new URL(url); } catch {
+    bookmarkStatus.textContent = 'Invalid URL — please enter a valid address.';
+    bookmarkStatus.className = 'status-bar status-bar--error';
+    return;
+  }
+
+  // Deduplicate by URL
+  if (bookmarks.some(b => b.url === url)) {
+    bookmarkStatus.textContent = 'That URL is already bookmarked.';
+    bookmarkStatus.className = 'status-bar status-bar--error';
+    return;
+  }
+
+  bookmarks.unshift({ url, label: label.trim(), id: Date.now() });
+  saveBookmarks();
+  renderBookmarks();
+  bookmarkStatus.textContent = '';
+  bookmarkStatus.className = 'status-bar';
+}
+
+function deleteBookmark(id) {
+  const li = bookmarksList.querySelector(`.bookmark-item[data-id="${id}"]`);
+  if (li) {
+    li.style.transition = 'opacity 150ms ease, transform 150ms ease';
+    li.style.opacity = '0';
+    li.style.transform = 'translateX(10px)';
+  }
+  setTimeout(() => {
+    bookmarks = bookmarks.filter(b => b.id !== id);
+    saveBookmarks();
+    renderBookmarks();
+  }, 150);
+}
+
+bookmarksForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  addBookmark(bookmarkUrl.value, bookmarkLabel.value);
+  bookmarkUrl.value = '';
+  bookmarkLabel.value = '';
+  bookmarkUrl.focus();
+});
+
+loadBookmarks();
+renderBookmarks();


### PR DESCRIPTION
Closes #2

## Changes
- **`tools/bookmarks.js`** — new ES module following the same pattern as `notes.js`:
  - `localStorage` persistence under key `peer-bookmarks`
  - Add bookmark via URL + optional label form
  - URL deduplication (prevents exact-URL duplicates)
  - Auto-prefixes `https://` if scheme is missing
  - `URL()` constructor validation with inline error message
  - Delete with 150ms fade-out animation
- **Favicons** — loaded from Google's public s2 favicon API (`https://www.google.com/s2/favicons?domain=<domain>&sz=16`); falls back to 🔖 emoji on image error
- **`index.html`** — Bookmarks tab button + panel section + nav link
- **`styles.css`** — matching design system styles (same tokens, animations, scrollbar treatment as Notes)
- **`script.js`** — imports `tools/bookmarks.js`

## Accessibility
- `sr-only` labels on all form inputs
- `aria-live` polite on bookmark count and status bar
- `aria-label` on every delete button with bookmark title/URL
- Links open `target="_blank" rel="noopener noreferrer"`

## Test Plan
- [ ] Add a URL without label — shows URL as link text, favicon loads
- [ ] Add a URL with label — shows label as link text, URL shown below
- [ ] Add duplicate URL — shows error, no duplicate added
- [ ] Add invalid string (e.g. `not a url`) — shows validation error
- [ ] Add bare domain (`github.com`) — auto-prefixes https, saves correctly
- [ ] Delete bookmark — fades out, removed from localStorage
- [ ] Reload page — bookmarks persist from localStorage
- [ ] Keyboard: tab through form, Enter submits, delete button focusable
- [ ] Dark mode — all elements use CSS custom properties correctly
- [ ] Mobile — form wraps correctly on narrow viewports