### PR TITLE
fix(pomodoro): use setUTCDate in currentStreak to avoid DST skew

### DIFF
--- a/tools/pomodoro.js
+++ b/tools/pomodoro.js
@@ -109,10 +109,10 @@ function currentStreak() {
     const key = d.toISOString().slice(0, 10);
     if (days.has(key)) {
       streak++;
-      d.setDate(d.getDate() - 1);
+      d.setUTCDate(d.getUTCDate() - 1);
     } else if (key === todayStr()) {
       // Today hasn't had a session yet — skip it without breaking streak
-      d.setDate(d.getDate() - 1);
+      d.setUTCDate(d.getUTCDate() - 1);
     } else {
       break;
     }


### PR DESCRIPTION
Closes #34

## Summary
- Replace `d.setDate(d.getDate() - 1)` with `d.setUTCDate(d.getUTCDate() - 1)` in both branches of the `currentStreak()` walk-back loop

## Changes
- `tools/pomodoro.js` — 2-line change: `setDate`/`getDate` → `setUTCDate`/`getUTCDate`

## Why
`todayStr()` and all history entries use `new Date().toISOString().slice(0,10)` — UTC dates. The walk-back was using local-time `setDate`/`getDate`, which on DST transitions steps 23 or 25 hours instead of exactly 24. This makes `toISOString()` return the same UTC date twice or skip one, causing the streak count to be off by 1 on the two DST transition nights per year.

Using `setUTCDate`/`getUTCDate` keeps all arithmetic in UTC, consistent with how dates are stored.

## Test Plan
- [ ] Load the app, verify streak counter shows correct value
- [ ] Verify CI passes (HTML/CSS/JS/a11y validation)
- [ ] No logic changes — only the arithmetic domain changes from local to UTC

## Evidence
```
fix(pomodoro): use setUTCDate in currentStreak to avoid DST skew
 tools/pomodoro.js | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```