### PR TITLE
fix(pomodoro): cap currentStreak walk-back at 365 iterations

### DIFF
--- a/tools/pomodoro.js
+++ b/tools/pomodoro.js
@@ -102,10 +102,11 @@ function currentStreak() {
   const days = new Set(history.map(e => e.date));
 
   let streak = 0;
+  let limit = 365; // safety cap — streaks beyond 365 days are extraordinary
   const d = new Date();
   // Walk backwards from today; allow today to count even if no session yet
   // (streak reflects yesterday→… continuity; today breaks it only if it's past midnight and no session)
-  while (true) {
+  while (limit-- > 0) {
     const key = d.toISOString().slice(0, 10);
     if (days.has(key)) {
       streak++;


### PR DESCRIPTION
Closes #37

## Summary
- Added `let limit = 365` guard to `currentStreak()` in `tools/pomodoro.js`
- Changed `while (true)` to `while (limit-- > 0)`
- Prevents unbounded iteration on corrupt or pathologically large history data

## Changes
- `tools/pomodoro.js` — two-line change: add limit variable, condition on while loop

## Test Plan
- [ ] Normal streak (e.g. 3-day) still displays correctly
- [ ] Fresh install (no history) shows 0 — no loop at all
- [ ] Behaviour is identical to before for all typical inputs
- [ ] No JS errors in console

## Evidence
Minimal diff — guard variable inserted immediately before the loop, no logic changes for the happy path.