### PR TITLE
feat(tools): add Unix timestamp converter

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="bookmarks">Bookmarks</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="pomodoro">Pomodoro</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="jwt">JWT</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="timestamp">Timestamp</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -94,6 +95,9 @@
         </button>
         <button class="tab" role="tab" aria-selected="false" aria-controls="panel-jwt" id="tab-jwt" data-panel="jwt" tabindex="-1">
           <span class="tab__icon" aria-hidden="true">🔑</span> JWT
+        </button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="panel-timestamp" id="tab-timestamp" data-panel="timestamp" tabindex="-1">
+          <span class="tab__icon" aria-hidden="true">⏱</span> Timestamp
         </button>
       </div>
     </div>
@@ -641,6 +645,108 @@
               </div>
               <pre class="code-preview" id="jwtExpiry" aria-label="JWT timestamp details" aria-live="polite" tabindex="0" hidden></pre>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════════════════════════
+           Unix Timestamp Converter
+           ═══════════════════════════════ -->
+      <section
+        id="panel-timestamp"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-timestamp"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">Unix Timestamp Converter</h2>
+              <p class="tool__desc">Convert between Unix epoch timestamps and human-readable dates. Seconds and milliseconds are auto-detected.</p>
+            </div>
+          </div>
+
+          <div class="tool__body">
+
+            <!-- Input row -->
+            <div class="tool__body--split">
+              <div class="tool__pane">
+                <div class="pane__header">
+                  <span class="pane__label">Epoch</span>
+                  <div class="pane__actions">
+                    <button class="btn btn--sm" id="tsNow">Now</button>
+                    <button class="btn btn--sm btn--secondary" id="tsFromEpoch">→ Date</button>
+                    <button class="btn btn--sm btn--ghost" id="tsClear">Clear</button>
+                  </div>
+                </div>
+                <input
+                  type="text"
+                  id="tsEpoch"
+                  class="code-area code-area--single"
+                  placeholder="e.g. 1709999999 or 1709999999000"
+                  spellcheck="false"
+                  autocomplete="off"
+                  inputmode="numeric"
+                  aria-label="Unix epoch input (seconds or milliseconds)"
+                >
+              </div>
+
+              <div class="tool__pane">
+                <div class="pane__header">
+                  <span class="pane__label">Date / Time</span>
+                  <div class="pane__actions">
+                    <button class="btn btn--sm btn--secondary" id="tsFromDate">→ Epoch</button>
+                  </div>
+                </div>
+                <input
+                  type="datetime-local"
+                  id="tsDatetime"
+                  class="code-area code-area--single"
+                  aria-label="Date and time picker"
+                >
+              </div>
+            </div>
+
+            <div class="status-bar" id="tsStatus" aria-live="polite" role="status"></div>
+
+            <!-- Output grid -->
+            <div class="tool__pane tool__pane--top">
+              <div class="pane__header">
+                <span class="pane__label">Results</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="tsCopyEpoch" disabled>Copy Epoch</button>
+                  <button class="btn btn--sm btn--ghost" id="tsCopyDate" disabled>Copy ISO</button>
+                </div>
+              </div>
+              <dl class="ts-results" aria-live="polite">
+                <div class="ts-result-row">
+                  <dt>ISO 8601</dt>
+                  <dd id="tsOutIso">—</dd>
+                </div>
+                <div class="ts-result-row">
+                  <dt>Local time</dt>
+                  <dd id="tsOutLocal">—</dd>
+                </div>
+                <div class="ts-result-row">
+                  <dt>UTC</dt>
+                  <dd id="tsOutUtc">—</dd>
+                </div>
+                <div class="ts-result-row">
+                  <dt>Relative</dt>
+                  <dd id="tsOutRelative">—</dd>
+                </div>
+                <div class="ts-result-row">
+                  <dt>Epoch (s)</dt>
+                  <dd id="tsOutEpochS">—</dd>
+                </div>
+                <div class="ts-result-row">
+                  <dt>Epoch (ms)</dt>
+                  <dd id="tsOutEpochMs">—</dd>
+                </div>
+              </dl>
+            </div>
+
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -15,3 +15,4 @@ import './tools/url.js';
 import './tools/bookmarks.js';
 import './tools/pomodoro.js';
 import './tools/jwt.js';
+import './tools/timestamp.js';

--- a/styles.css
+++ b/styles.css
@@ -529,6 +529,7 @@ main {
 }
 .code-area::placeholder { color: var(--color-text-muted); opacity: 0.6; }
 .code-area[readonly] { color: var(--color-text-muted); cursor: default; }
+.code-area--single { min-height: unset; height: 2.8rem; resize: none; padding-top: 0.6rem; padding-bottom: 0.6rem; }
 
 /* ============================================
    Code preview (pre)
@@ -1361,4 +1362,46 @@ main {
   color: var(--color-text-muted);
   background: var(--color-surface);
   transition: background var(--transition-slow), border-color var(--transition-slow);
+}
+
+/* ============================================
+   Timestamp Converter
+   ============================================ */
+.ts-results {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.ts-result-row {
+  display: grid;
+  grid-template-columns: 9rem 1fr;
+  border-bottom: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+.ts-result-row:last-child { border-bottom: none; }
+.ts-result-row dt {
+  padding: 0.55rem 0.875rem;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-weight: 600;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  border-right: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+.ts-result-row dd {
+  margin: 0;
+  padding: 0.55rem 0.875rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  display: flex;
+  align-items: center;
+  word-break: break-all;
 }

--- a/tools/timestamp.js
+++ b/tools/timestamp.js
@@ -1,0 +1,141 @@
+// Unix Timestamp Converter
+
+import { copyText } from './utils.js';
+
+const epochInput    = document.getElementById('tsEpoch');
+const datetimeInput = document.getElementById('tsDatetime');
+const tsStatus      = document.getElementById('tsStatus');
+const tsNow         = document.getElementById('tsNow');
+const tsFromEpoch   = document.getElementById('tsFromEpoch');
+const tsFromDate    = document.getElementById('tsFromDate');
+const tsClear       = document.getElementById('tsClear');
+const tsCopyEpoch   = document.getElementById('tsCopyEpoch');
+const tsCopyDate    = document.getElementById('tsCopyDate');
+
+const outIso      = document.getElementById('tsOutIso');
+const outLocal    = document.getElementById('tsOutLocal');
+const outUtc      = document.getElementById('tsOutUtc');
+const outRelative = document.getElementById('tsOutRelative');
+const outEpochMs  = document.getElementById('tsOutEpochMs');
+const outEpochS   = document.getElementById('tsOutEpochS');
+
+function setStatus(msg, type = '') {
+  tsStatus.textContent = msg;
+  tsStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
+}
+
+function relativeTime(ms) {
+  const diff = ms - Date.now();
+  const abs = Math.abs(diff);
+  const future = diff > 0;
+
+  const units = [
+    { label: 'year',   ms: 365.25 * 24 * 60 * 60 * 1000 },
+    { label: 'month',  ms: 30.44 * 24 * 60 * 60 * 1000 },
+    { label: 'day',    ms: 24 * 60 * 60 * 1000 },
+    { label: 'hour',   ms: 60 * 60 * 1000 },
+    { label: 'minute', ms: 60 * 1000 },
+    { label: 'second', ms: 1000 },
+  ];
+
+  for (const unit of units) {
+    const n = Math.floor(abs / unit.ms);
+    if (n >= 1) {
+      const label = `${n} ${unit.label}${n !== 1 ? 's' : ''}`;
+      return future ? `in ${label}` : `${label} ago`;
+    }
+  }
+  return 'just now';
+}
+
+function populateOutputs(ms) {
+  const d = new Date(ms);
+  outIso.textContent      = d.toISOString();
+  outLocal.textContent    = d.toLocaleString(undefined, { timeZoneName: 'short' });
+  outUtc.textContent      = d.toUTCString();
+  outRelative.textContent = relativeTime(ms);
+  outEpochMs.textContent  = String(ms);
+  outEpochS.textContent   = String(Math.floor(ms / 1000));
+  tsCopyEpoch.disabled = false;
+  tsCopyDate.disabled  = false;
+}
+
+function clearOutputs() {
+  [outIso, outLocal, outUtc, outRelative, outEpochMs, outEpochS].forEach(el => {
+    el.textContent = '—';
+  });
+  tsCopyEpoch.disabled = true;
+  tsCopyDate.disabled  = true;
+}
+
+// Epoch → datetime
+tsFromEpoch.addEventListener('click', () => {
+  const raw = epochInput.value.trim();
+  if (!raw) { setStatus('Enter an epoch value.', 'error'); return; }
+  if (!/^\d+$/.test(raw)) { setStatus('Epoch must be a positive integer.', 'error'); return; }
+
+  let ms = Number(raw);
+  // Auto-detect seconds vs milliseconds: < 1e12 → seconds
+  if (ms < 1e12) ms *= 1000;
+
+  const d = new Date(ms);
+  if (isNaN(d.getTime())) { setStatus('Invalid epoch value.', 'error'); return; }
+
+  // Sync datetime-local input (uses local time, ISO-like without Z)
+  const pad = n => String(n).padStart(2, '0');
+  const local = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  datetimeInput.value = local;
+
+  populateOutputs(ms);
+  setStatus(`Converted · auto-detected as ${raw.length >= 13 ? 'milliseconds' : 'seconds'}`, 'ok');
+});
+
+// Datetime → epoch
+tsFromDate.addEventListener('click', () => {
+  const raw = datetimeInput.value;
+  if (!raw) { setStatus('Pick a date and time.', 'error'); return; }
+
+  const d = new Date(raw); // datetime-local is parsed as local time
+  if (isNaN(d.getTime())) { setStatus('Invalid date/time.', 'error'); return; }
+
+  epochInput.value = String(Math.floor(d.getTime() / 1000));
+  populateOutputs(d.getTime());
+  setStatus('Converted · local time assumed', 'ok');
+});
+
+// Now
+tsNow.addEventListener('click', () => {
+  const now = Date.now();
+  epochInput.value = String(Math.floor(now / 1000));
+
+  const d = new Date(now);
+  const pad = n => String(n).padStart(2, '0');
+  datetimeInput.value = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+  populateOutputs(now);
+  setStatus('Loaded current time', 'ok');
+});
+
+// Clear
+tsClear.addEventListener('click', () => {
+  epochInput.value    = '';
+  datetimeInput.value = '';
+  clearOutputs();
+  setStatus('');
+  epochInput.focus();
+});
+
+// Copy epoch (seconds)
+tsCopyEpoch.addEventListener('click', () => copyText(outEpochS.textContent, tsCopyEpoch));
+
+// Copy ISO date
+tsCopyDate.addEventListener('click', () => copyText(outIso.textContent, tsCopyDate));
+
+// Enter key on epoch input triggers conversion
+epochInput.addEventListener('keydown', e => {
+  if (e.key === 'Enter') tsFromEpoch.click();
+});
+
+datetimeInput.addEventListener('keydown', e => {
+  if (e.key === 'Enter') tsFromDate.click();
+});


### PR DESCRIPTION
## Summary

- New **Timestamp** tab in nav and tablist
- Two-way conversion: epoch → datetime and datetime → epoch
- Seconds/milliseconds auto-detected (< 1e12 → seconds)
- Outputs: ISO 8601, local time with tz, UTC, relative ("3 days ago"), epoch (s), epoch (ms)
- **Now** button fills current time into both fields
- **Enter key** on either input triggers conversion
- Copy buttons for epoch (seconds) and ISO 8601
- `aria-live="polite"` on results `<dl>`, `aria-label` on all inputs, `role="status"` on status bar
- Works fully offline — no external calls

## Changes

| File | Change |
|------|--------|
| `tools/timestamp.js` | New module — all converter logic |
| `index.html` | Tab button, nav link, panel with input pair + results grid |
| `script.js` | Import `timestamp.js` |
| `styles.css` | `.code-area--single` for inline inputs, `.ts-results`/`.ts-result-row` for results grid |

## Test Plan

- [ ] Enter `1709999999` → should show 2024-03-09, "~2 years ago"
- [ ] Enter `1709999999000` (ms) → same result, status says "milliseconds"
- [ ] Pick a date in the datetime picker → epoch updates correctly
- [ ] "Now" → both fields populate, relative shows "just now"
- [ ] Copy Epoch → clipboard has seconds value
- [ ] Copy ISO → clipboard has ISO 8601 string
- [ ] Clear → inputs empty, outputs reset to "—"
- [ ] Enter key on epoch input → triggers conversion
- [ ] Tab keyboard navigation includes new Timestamp tab
- [ ] CI passes (validate, lighthouse, CodeQL)

## Evidence

Commit: de55543

Closes #41