### PR TITLE
refactor(ids): replace Date.now()+Math.random() with crypto.randomUUID()

### DIFF
--- a/tools/bookmarks.js
+++ b/tools/bookmarks.js
@@ -126,7 +126,7 @@ function addBookmark(rawUrl, label) {
     return;
   }
 
-  bookmarks.unshift({ url, label: label.trim(), id: Date.now() });
+  bookmarks.unshift({ url, label: label.trim(), id: crypto.randomUUID() });
   saveBookmarks();
   renderBookmarks();
   bookmarkStatus.textContent = '';
@@ -191,7 +191,7 @@ bookmarksImportFile.addEventListener('change', () => {
       const newBookmarks = imported.filter(b => !existingUrls.has(normalizeUrl(b.url)));
       newBookmarks.forEach(b => {
         b.url = normalizeUrl(b.url);
-        if (!b.id) b.id = Date.now() + Math.random();
+        if (!b.id) b.id = crypto.randomUUID();
         if (!b.label) b.label = '';
       });
       bookmarks = [...newBookmarks, ...bookmarks];

--- a/tools/notes.js
+++ b/tools/notes.js
@@ -57,7 +57,7 @@ function renderNotes() {
 function addNote(text) {
   const trimmed = text.trim();
   if (!trimmed) return;
-  notes.unshift({ text: trimmed, id: Date.now() });
+  notes.unshift({ text: trimmed, id: crypto.randomUUID() });
   saveNotes();
   renderNotes();
 }
@@ -124,7 +124,7 @@ notesImportFile.addEventListener('change', () => {
       // Deduplicate by text content
       const existingTexts = new Set(notes.map(n => n.text));
       const newNotes = imported.filter(n => !existingTexts.has(n.text));
-      newNotes.forEach(n => { if (!n.id) n.id = Date.now() + Math.random(); });
+      newNotes.forEach(n => { if (!n.id) n.id = crypto.randomUUID(); });
       notes = [...newNotes, ...notes];
       saveNotes();
       renderNotes();


### PR DESCRIPTION
## Summary

- Replace `Date.now()` (numeric) and `Date.now() + Math.random()` (float) with `crypto.randomUUID()` in notes and bookmarks ID generation
- 4 call sites: `addNote`, import fallback in notes; `addBookmark`, import fallback in bookmarks

## Motivation

`Date.now()` returns a number, not a UUID. The import fallback `Date.now() + Math.random()` produces a float with floating-point precision issues at scale, and is semantically wrong for an ID. `crypto.randomUUID()` is the correct primitive — RFC 4122 compliant, collision-resistant, available in all target browsers (Chrome 92+, Firefox 95+, Safari 15.4+).

## Changes

- `tools/notes.js`: lines 60, 127
- `tools/bookmarks.js`: lines 129, 194

## Compatibility

IDs are only used as opaque keys for delete/dedup — string UUIDs are drop-in replacements. Existing localStorage data with numeric IDs continues to work (delete/filter by `===` works for both string and numeric comparisons when the same value is used throughout a session).

## Test Plan

- [ ] Add a note → check localStorage, confirm ID is a UUID string
- [ ] Delete the note → confirm it's removed (filter by UUID works)
- [ ] Import notes JSON without IDs → confirm IDs are assigned as UUIDs
- [ ] Same for bookmarks

Closes #49