### PR TITLE
refactor(timestamp): hoist pad helper to module scope

### DIFF
--- a/tools/timestamp.js
+++ b/tools/timestamp.js
@@ -19,6 +19,8 @@ const outRelative = document.getElementById('tsOutRelative');
 const outEpochMs  = document.getElementById('tsOutEpochMs');
 const outEpochS   = document.getElementById('tsOutEpochS');
 
+const pad = n => String(n).padStart(2, '0');
+
 function setStatus(msg, type = '') {
   tsStatus.textContent = msg;
   tsStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
@@ -82,7 +84,6 @@ tsFromEpoch.addEventListener('click', () => {
   if (isNaN(d.getTime())) { setStatus('Invalid epoch value.', 'error'); return; }
 
   // Sync datetime-local input (uses local time, ISO-like without Z)
-  const pad = n => String(n).padStart(2, '0');
   const local = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   datetimeInput.value = local;
 
@@ -109,7 +110,6 @@ tsNow.addEventListener('click', () => {
   epochInput.value = String(Math.floor(now / 1000));
 
   const d = new Date(now);
-  const pad = n => String(n).padStart(2, '0');
   datetimeInput.value = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 
   populateOutputs(now);


### PR DESCRIPTION
Closes #51

## Summary
Moves the duplicate `pad` helper to module scope, eliminating two identical inline definitions.

## Changes
- Added `const pad = n => String(n).padStart(2, '0');` at module scope after the output element constants
- Removed inline `const pad` from `tsFromEpoch` click handler
- Removed inline `const pad` from `tsNow` click handler

No logic changes — purely structural deduplication.

## Test Plan
- Click "From Epoch" with a valid epoch → datetime-local syncs correctly
- Click "Now" → datetime-local populates with current local time
- Both use the module-scoped `pad` — same output as before

## Evidence
Diff is +2/-2: one addition at module scope, two removals from handlers.