### PR TITLE
feat(nav): URL fragment routing for deep-linking to tools

### DIFF
--- a/tools/tabs.js
+++ b/tools/tabs.js
@@ -21,7 +21,10 @@ function activateTab(panelId) {
 }
 
 tabs.forEach(tab => {
-  tab.addEventListener('click', () => activateTab(tab.dataset.panel));
+  tab.addEventListener('click', () => {
+    activateTab(tab.dataset.panel);
+    history.replaceState(null, '', `#${tab.dataset.panel}`);
+  });
 
   // Keyboard navigation: arrow keys cycle tabs
   tab.addEventListener('keydown', (e) => {
@@ -52,14 +55,32 @@ document.querySelectorAll('.nav-tool-link').forEach(link => {
   link.addEventListener('click', (e) => {
     e.preventDefault();
     activateTab(link.dataset.tab);
+    history.replaceState(null, '', `#${link.dataset.tab}`);
     document.getElementById('tools').scrollIntoView({ behavior: 'smooth' });
   });
 });
 
-// Restore last-used tab
+// Restore tab from URL hash, sessionStorage fallback, else 'json'
 (function restoreTab() {
-  const saved = sessionStorage.getItem('devtools-tab');
-  if (saved && document.getElementById(`panel-${saved}`)) {
-    activateTab(saved);
+  const validIds = new Set([...panels].map(p => p.id.replace('panel-', '')));
+
+  function tabFromHash() {
+    const hash = window.location.hash.slice(1);
+    return validIds.has(hash) ? hash : null;
   }
+
+  function activate(id) {
+    activateTab(id);
+    history.replaceState(null, '', `#${id}`);
+  }
+
+  const initial = tabFromHash()
+    || sessionStorage.getItem('devtools-tab')
+    || 'json';
+  activate(validIds.has(initial) ? initial : 'json');
+
+  window.addEventListener('popstate', () => {
+    const id = tabFromHash() || 'json';
+    activateTab(id);
+  });
 })();


### PR DESCRIPTION
Closes #42

## Summary
- Read `window.location.hash` on load — activate matching tab if valid
- Falls back to `sessionStorage` value, then `json` tab
- Tab clicks and nav-tool-link clicks update hash via `history.replaceState` (no history push, no scroll jump)
- `popstate` listener ensures back/forward navigation switches tabs correctly

## Changes
- `tools/tabs.js`: ~26 lines changed — hash read on init, replaceState on switch, popstate handler

## Test Plan
- [ ] Visit `/peer-webapp/#jwt` → JWT tab opens
- [ ] Visit `/peer-webapp/#regex` → Regex tab opens
- [ ] Visit `/peer-webapp/` → JSON tab opens (default)
- [ ] Visit `/peer-webapp/#bogus` → JSON tab opens (fallback)
- [ ] Switch tabs → URL hash updates in address bar
- [ ] Browser back/forward → tab switches accordingly
- [ ] No visual change to tab appearance

## Evidence
Single-file change, all acceptance criteria addressed.