### PR TITLE
fix(nav): handle hashchange for manual address-bar edits

### DIFF
--- a/tools/tabs.js
+++ b/tools/tabs.js
@@ -83,4 +83,15 @@ document.querySelectorAll('.nav-tool-link').forEach(link => {
     const id = tabFromHash() || 'json';
     activateTab(id);
   });
+
+  // hashchange fires when the user manually edits the address bar hash;
+  // popstate does not always fire in that case. Guard against double-activation
+  // (browsers may fire both) by checking if the resolved tab actually changed.
+  window.addEventListener('hashchange', () => {
+    const id = tabFromHash() || 'json';
+    if (sessionStorage.getItem('devtools-tab') !== id) {
+      activateTab(id);
+      history.replaceState(null, '', `#${id}`);
+    }
+  });
 })();


### PR DESCRIPTION
Closes #59

## Summary
- Adds a `hashchange` event listener inside the `restoreTab` IIFE alongside the existing `popstate` handler
- Covers the case where the user manually edits the URL hash in the address bar and presses Enter — this fires `hashchange` but not always `popstate`
- Guards against double-activation (browsers that fire both events) by comparing the resolved tab id against the value already persisted in `sessionStorage`; if they match the tab is already active and no redundant work is done

## Changes
- `tools/tabs.js`: +11 lines — `hashchange` listener with dedup guard

## Test Plan
- [ ] Open the app, note current tab is `#json`
- [ ] Click in the address bar, change hash to `#regex`, press Enter — Regex tab activates
- [ ] Change hash to `#bogus`, press Enter — falls back to JSON tab
- [ ] Use browser Back/Forward — `popstate` path still works correctly
- [ ] Click tabs normally — no duplicate state updates

## Evidence
Change is +11 lines in a single file. Logic mirrors the existing `popstate` handler with an added identity check to prevent redundant re-renders.