### PR TITLE
feat(hash): compare mode for hash verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,43 +891,97 @@
               </div>
               <div class="base-grid" role="group" aria-label="Hash outputs">
 
-                <div class="base-row">
-                  <label class="base-label" for="hashOut256">SHA-256</label>
-                  <input
-                    type="text"
-                    id="hashOut256"
-                    class="base-input"
-                    readonly
-                    spellcheck="false"
-                    aria-label="SHA-256 hash output"
-                  >
-                  <button class="btn btn--sm btn--ghost" id="hashCopy256" disabled>Copy</button>
+                <div class="hash-group">
+                  <div class="base-row">
+                    <label class="base-label" for="hashOut256">SHA-256</label>
+                    <input
+                      type="text"
+                      id="hashOut256"
+                      class="base-input"
+                      readonly
+                      spellcheck="false"
+                      aria-label="SHA-256 hash output"
+                    >
+                    <div class="hash-row-btns">
+                      <button class="btn btn--sm btn--ghost" id="hashCopy256" disabled>Copy</button>
+                      <button class="btn btn--sm btn--ghost" id="hashCompareToggle256" aria-expanded="false" aria-controls="hashCompareRow256">Compare</button>
+                    </div>
+                  </div>
+                  <div class="hash-compare-row" id="hashCompareRow256" hidden>
+                    <span class="base-label" aria-hidden="true"></span>
+                    <input
+                      type="text"
+                      id="hashExpected256"
+                      class="base-input"
+                      placeholder="Paste expected SHA-256…"
+                      spellcheck="false"
+                      autocomplete="off"
+                      aria-label="Expected SHA-256 hash to compare"
+                    >
+                    <span class="hash-match" id="hashMatch256" aria-live="polite"></span>
+                  </div>
                 </div>
 
-                <div class="base-row">
-                  <label class="base-label" for="hashOut384">SHA-384</label>
-                  <input
-                    type="text"
-                    id="hashOut384"
-                    class="base-input"
-                    readonly
-                    spellcheck="false"
-                    aria-label="SHA-384 hash output"
-                  >
-                  <button class="btn btn--sm btn--ghost" id="hashCopy384" disabled>Copy</button>
+                <div class="hash-group">
+                  <div class="base-row">
+                    <label class="base-label" for="hashOut384">SHA-384</label>
+                    <input
+                      type="text"
+                      id="hashOut384"
+                      class="base-input"
+                      readonly
+                      spellcheck="false"
+                      aria-label="SHA-384 hash output"
+                    >
+                    <div class="hash-row-btns">
+                      <button class="btn btn--sm btn--ghost" id="hashCopy384" disabled>Copy</button>
+                      <button class="btn btn--sm btn--ghost" id="hashCompareToggle384" aria-expanded="false" aria-controls="hashCompareRow384">Compare</button>
+                    </div>
+                  </div>
+                  <div class="hash-compare-row" id="hashCompareRow384" hidden>
+                    <span class="base-label" aria-hidden="true"></span>
+                    <input
+                      type="text"
+                      id="hashExpected384"
+                      class="base-input"
+                      placeholder="Paste expected SHA-384…"
+                      spellcheck="false"
+                      autocomplete="off"
+                      aria-label="Expected SHA-384 hash to compare"
+                    >
+                    <span class="hash-match" id="hashMatch384" aria-live="polite"></span>
+                  </div>
                 </div>
 
-                <div class="base-row">
-                  <label class="base-label" for="hashOut512">SHA-512</label>
-                  <input
-                    type="text"
-                    id="hashOut512"
-                    class="base-input"
-                    readonly
-                    spellcheck="false"
-                    aria-label="SHA-512 hash output"
-                  >
-                  <button class="btn btn--sm btn--ghost" id="hashCopy512" disabled>Copy</button>
+                <div class="hash-group">
+                  <div class="base-row">
+                    <label class="base-label" for="hashOut512">SHA-512</label>
+                    <input
+                      type="text"
+                      id="hashOut512"
+                      class="base-input"
+                      readonly
+                      spellcheck="false"
+                      aria-label="SHA-512 hash output"
+                    >
+                    <div class="hash-row-btns">
+                      <button class="btn btn--sm btn--ghost" id="hashCopy512" disabled>Copy</button>
+                      <button class="btn btn--sm btn--ghost" id="hashCompareToggle512" aria-expanded="false" aria-controls="hashCompareRow512">Compare</button>
+                    </div>
+                  </div>
+                  <div class="hash-compare-row" id="hashCompareRow512" hidden>
+                    <span class="base-label" aria-hidden="true"></span>
+                    <input
+                      type="text"
+                      id="hashExpected512"
+                      class="base-input"
+                      placeholder="Paste expected SHA-512…"
+                      spellcheck="false"
+                      autocomplete="off"
+                      aria-label="Expected SHA-512 hash to compare"
+                    >
+                    <span class="hash-match" id="hashMatch512" aria-live="polite"></span>
+                  </div>
                 </div>
 
               </div>

--- a/styles.css
+++ b/styles.css
@@ -1406,6 +1406,37 @@ main {
   grid-template-columns: 4.5rem 1fr auto;
 }
 
+/* Hash compare mode */
+.hash-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.hash-row-btns {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.hash-compare-row {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.hash-match {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+  min-width: 5.5rem;
+  text-align: center;
+}
+
+.hash-match--ok  { color: var(--color-ok); }
+.hash-match--err { color: var(--color-danger); }
+
 /* ============================================
    Footer
    ============================================ */

--- a/tools/hash.js
+++ b/tools/hash.js
@@ -15,6 +15,20 @@ const copyBtn512  = document.getElementById('hashCopy512');
 const casingBtn   = document.getElementById('hashCasing');
 const clearBtn    = document.getElementById('hashClear');
 
+// Compare mode elements
+const compareToggle256 = document.getElementById('hashCompareToggle256');
+const compareToggle384 = document.getElementById('hashCompareToggle384');
+const compareToggle512 = document.getElementById('hashCompareToggle512');
+const compareRow256    = document.getElementById('hashCompareRow256');
+const compareRow384    = document.getElementById('hashCompareRow384');
+const compareRow512    = document.getElementById('hashCompareRow512');
+const expected256      = document.getElementById('hashExpected256');
+const expected384      = document.getElementById('hashExpected384');
+const expected512      = document.getElementById('hashExpected512');
+const matchStatus256   = document.getElementById('hashMatch256');
+const matchStatus384   = document.getElementById('hashMatch384');
+const matchStatus512   = document.getElementById('hashMatch512');
+
 let upperCase = false;
 
 // ---------------------------------------------------------------------------
@@ -38,6 +52,48 @@ function applyCase(hex) {
 }
 
 // ---------------------------------------------------------------------------
+// Compare mode
+// ---------------------------------------------------------------------------
+
+function updateMatchStatus(expectedInput, statusEl, computedOutput) {
+  const expected = expectedInput.value.trim().toLowerCase();
+  const computed  = computedOutput.value.toLowerCase();
+
+  if (!expected || !computed) {
+    statusEl.textContent = '';
+    statusEl.className = 'hash-match';
+    return;
+  }
+
+  const match = computed === expected;
+  statusEl.textContent = match ? '✓ Match' : '✗ Mismatch';
+  statusEl.className   = 'hash-match ' + (match ? 'hash-match--ok' : 'hash-match--err');
+}
+
+function clearMatchStatus(statusEl, expectedInput) {
+  expectedInput.value  = '';
+  statusEl.textContent = '';
+  statusEl.className   = 'hash-match';
+}
+
+function wireCompareToggle(toggleBtn, row, expectedInput, statusEl, computedOutput) {
+  toggleBtn.addEventListener('click', () => {
+    const expanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+    toggleBtn.setAttribute('aria-expanded', String(!expanded));
+    row.hidden = expanded;
+    if (!expanded) expectedInput.focus();
+  });
+
+  expectedInput.addEventListener('input', () => {
+    updateMatchStatus(expectedInput, statusEl, computedOutput);
+  });
+}
+
+wireCompareToggle(compareToggle256, compareRow256, expected256, matchStatus256, out256);
+wireCompareToggle(compareToggle384, compareRow384, expected384, matchStatus384, out384);
+wireCompareToggle(compareToggle512, compareRow512, expected512, matchStatus512, out512);
+
+// ---------------------------------------------------------------------------
 // Compute all three hashes in parallel
 // ---------------------------------------------------------------------------
 async function computeHashes() {
@@ -50,6 +106,9 @@ async function computeHashes() {
     copyBtn256.disabled = true;
     copyBtn384.disabled = true;
     copyBtn512.disabled = true;
+    clearMatchStatus(matchStatus256, expected256);
+    clearMatchStatus(matchStatus384, expected384);
+    clearMatchStatus(matchStatus512, expected512);
     setStatus('');
     return;
   }
@@ -71,6 +130,11 @@ async function computeHashes() {
     copyBtn256.disabled = false;
     copyBtn384.disabled = false;
     copyBtn512.disabled = false;
+
+    // Re-evaluate open compare fields against the new hashes
+    updateMatchStatus(expected256, matchStatus256, out256);
+    updateMatchStatus(expected384, matchStatus384, out384);
+    updateMatchStatus(expected512, matchStatus512, out512);
 
     setStatus(`${byteLen} byte${byteLen !== 1 ? 's' : ''} · ${text.length} char${text.length !== 1 ? 's' : ''}`, 'ok');
   } catch {
@@ -101,6 +165,7 @@ casingBtn.addEventListener('click', () => {
   if (out256.value) out256.value = applyCase(out256.value.toLowerCase());
   if (out384.value) out384.value = applyCase(out384.value.toLowerCase());
   if (out512.value) out512.value = applyCase(out512.value.toLowerCase());
+  // Case toggle doesn't change hash value — comparison is always case-insensitive
 });
 
 clearBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

Adds compare mode to the SHA Hash Generator tool, closing the full checksum verification workflow: compute hash → paste expected → instant match/mismatch feedback.

- Each SHA output row gets a **Compare** toggle (collapsed by default, `aria-expanded`)
- Expanding reveals a text input for the expected hash
- Indicator updates on every keystroke — case-insensitive string comparison
- ✓ Match (green) / ✗ Mismatch (red) with semantic color **and** text (no color-only signal — accessible)
- Compare fields clear automatically when input changes or Clear is pressed
- All three SHA variants (256/384/512) work independently
- Zero new dependencies — pure string comparison, ~65 lines of JS

## Implementation notes

- Branched from `alpha/issue-61` so this stacks cleanly on the hash tool PR
- `updateMatchStatus` is called in `computeHashes()` so live-typing in the hash input re-evaluates open compare fields
- Case toggle doesn't affect comparison — both sides are `.toLowerCase()` before comparing
- `aria-live="polite"` on the match status element announces changes to screen readers

## Test plan

- [ ] Type text → SHA-256 computes → click Compare → paste the correct hash → see ✓ Match
- [ ] Paste incorrect hash → see ✗ Mismatch
- [ ] Change input text → compare field clears or re-evaluates (mismatch expected)
- [ ] Toggle UPPER casing on computed output → comparison still correct
- [ ] Click Clear → all compare fields reset
- [ ] Repeat for SHA-384 and SHA-512 independently
- [ ] Screen reader: match status announced on change

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)