### PR TITLE
feat(string): string utilities tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="jwt">JWT</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="timestamp">Timestamp</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="base">Base</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="string">String</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -102,6 +103,9 @@
         </button>
         <button class="tab" role="tab" aria-selected="false" aria-controls="panel-base" id="tab-base" data-panel="base" tabindex="-1">
           <span class="tab__icon" aria-hidden="true">01</span> Base
+        </button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="panel-string" id="tab-string" data-panel="string" tabindex="-1">
+          <span class="tab__icon" aria-hidden="true">Aa</span> String
         </button>
       </div>
     </div>
@@ -839,6 +843,93 @@
 
             <div class="status-bar" id="baseStatus" aria-live="polite" role="status"></div>
             <p class="base-bits" id="baseBits" aria-live="polite"></p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════════════════════════
+           String Utilities
+           ═══════════════════════════════ -->
+      <section
+        id="panel-string"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-string"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">String Utilities</h2>
+              <p class="tool__desc">Sort lines, deduplicate, convert case, and trim whitespace. Paste text, pick an operation, get the result instantly.</p>
+            </div>
+          </div>
+          <div class="tool__body tool__body--split">
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Input</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="strClear">Clear</button>
+                </div>
+              </div>
+              <textarea
+                class="code-area"
+                id="strInput"
+                placeholder="Paste or type text here…"
+                spellcheck="false"
+                autocomplete="off"
+                aria-label="String input"
+              ></textarea>
+              <p class="str-live-stats" id="strInputStats" aria-live="polite"></p>
+              <div class="status-bar" id="strStatus" aria-live="polite" role="status"></div>
+              <div class="str-ops" role="group" aria-label="String operations">
+                <div class="str-ops__group">
+                  <span class="str-ops__label">Sort</span>
+                  <div class="pane__actions">
+                    <button class="btn btn--sm" id="strSortAZ">A→Z</button>
+                    <button class="btn btn--sm btn--secondary" id="strSortZA">Z→A</button>
+                    <button class="btn btn--sm btn--ghost" id="strSortLen">Length</button>
+                  </div>
+                </div>
+                <div class="str-ops__group">
+                  <span class="str-ops__label">Case</span>
+                  <div class="pane__actions">
+                    <button class="btn btn--sm" id="strUpper">UPPER</button>
+                    <button class="btn btn--sm btn--secondary" id="strLower">lower</button>
+                    <button class="btn btn--sm btn--ghost" id="strTitle">Title</button>
+                    <button class="btn btn--sm btn--ghost" id="strCamel">camel</button>
+                    <button class="btn btn--sm btn--ghost" id="strSnake">snake</button>
+                    <button class="btn btn--sm btn--ghost" id="strKebab">kebab</button>
+                  </div>
+                </div>
+                <div class="str-ops__group">
+                  <span class="str-ops__label">Lines</span>
+                  <div class="pane__actions">
+                    <button class="btn btn--sm" id="strDedup">Deduplicate</button>
+                    <button class="btn btn--sm btn--secondary" id="strTrim">Trim</button>
+                    <button class="btn btn--sm btn--ghost" id="strRemoveBlanks">Remove Blanks</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Output</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="strCopy" disabled>Copy</button>
+                  <button class="btn btn--sm btn--ghost" id="strUseOutput" title="Load output back into input">↑ Use as Input</button>
+                </div>
+              </div>
+              <textarea
+                class="code-area"
+                id="strOutput"
+                placeholder="Result will appear here…"
+                readonly
+                spellcheck="false"
+                aria-label="String output"
+              ></textarea>
+              <p class="str-live-stats" id="strStats" aria-live="polite"></p>
+            </div>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -17,3 +17,4 @@ import './tools/pomodoro.js';
 import './tools/jwt.js';
 import './tools/timestamp.js';
 import './tools/base.js';
+import './tools/string.js';

--- a/styles.css
+++ b/styles.css
@@ -1455,3 +1455,39 @@ main {
   align-items: center;
   word-break: break-all;
 }
+
+/* ============================================
+   String Utilities
+   ============================================ */
+.str-ops {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 0.75rem;
+}
+
+.str-ops__group {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.str-ops__label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+  min-width: 2.75rem;
+  padding-top: 0.4rem;
+  flex-shrink: 0;
+}
+
+.str-live-stats {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  margin: 0.25rem 0 0;
+  min-height: 1em;
+  letter-spacing: 0.01em;
+}

--- a/tools/string.js
+++ b/tools/string.js
@@ -1,0 +1,132 @@
+// String Utilities
+
+import { copyText } from './utils.js';
+
+const strInput      = document.getElementById('strInput');
+const strOutput     = document.getElementById('strOutput');
+const strStatus     = document.getElementById('strStatus');
+const strInputStats = document.getElementById('strInputStats');
+const strStats      = document.getElementById('strStats');
+const strCopy       = document.getElementById('strCopy');
+
+function setStrStatus(msg, type = '') {
+  strStatus.textContent = msg;
+  strStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
+}
+
+function statsText(text) {
+  if (!text) return '';
+  const lines = text.split('\n').length;
+  const words = text.trim() ? text.trim().split(/\s+/).length : 0;
+  const chars = text.length;
+  return `Lines: ${lines} · Words: ${words} · Chars: ${chars}`;
+}
+
+function updateInputStats() {
+  strInputStats.textContent = strInput.value ? statsText(strInput.value) : '';
+}
+
+function applyTransform(fn, label) {
+  const input = strInput.value;
+  if (!input) { setStrStatus('Nothing to transform.', 'error'); return; }
+  const result = fn(input);
+  strOutput.value = result;
+  strCopy.disabled = false;
+  strStats.textContent = statsText(result);
+  setStrStatus(label, 'ok');
+}
+
+// Split text into words, handling camelCase, snake_case, kebab-case, and spaces
+function splitWords(str) {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[\s\-_.,;:!?()[\]{}'"/\\]+/)
+    .filter(w => w.length > 0);
+}
+
+// Sort
+document.getElementById('strSortAZ').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').sort((a, b) => a.localeCompare(b)).join('\n'), 'Sorted A→Z')
+);
+document.getElementById('strSortZA').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').sort((a, b) => b.localeCompare(a)).join('\n'), 'Sorted Z→A')
+);
+document.getElementById('strSortLen').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').sort((a, b) => a.length - b.length).join('\n'), 'Sorted by length')
+);
+
+// Case
+document.getElementById('strUpper').addEventListener('click', () =>
+  applyTransform(t => t.toUpperCase(), 'UPPERCASE')
+);
+document.getElementById('strLower').addEventListener('click', () =>
+  applyTransform(t => t.toLowerCase(), 'lowercase')
+);
+document.getElementById('strTitle').addEventListener('click', () =>
+  applyTransform(t => t.replace(/\w\S*/g, w => w[0].toUpperCase() + w.slice(1).toLowerCase()), 'Title Case')
+);
+document.getElementById('strCamel').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').map(line => {
+    const words = splitWords(line);
+    if (!words.length) return line;
+    return words[0].toLowerCase() +
+      words.slice(1).map(w => w[0].toUpperCase() + w.slice(1).toLowerCase()).join('');
+  }).join('\n'), 'camelCase')
+);
+document.getElementById('strSnake').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').map(line =>
+    splitWords(line).map(w => w.toLowerCase()).join('_') || line
+  ).join('\n'), 'snake_case')
+);
+document.getElementById('strKebab').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').map(line =>
+    splitWords(line).map(w => w.toLowerCase()).join('-') || line
+  ).join('\n'), 'kebab-case')
+);
+
+// Lines
+document.getElementById('strDedup').addEventListener('click', () =>
+  applyTransform(t => {
+    const seen = new Set();
+    return t.split('\n').filter(line => {
+      if (seen.has(line)) return false;
+      seen.add(line);
+      return true;
+    }).join('\n');
+  }, 'Duplicates removed')
+);
+document.getElementById('strTrim').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').map(line => line.trim()).join('\n'), 'Lines trimmed')
+);
+document.getElementById('strRemoveBlanks').addEventListener('click', () =>
+  applyTransform(t => t.split('\n').filter(line => line.trim()).join('\n'), 'Blank lines removed')
+);
+
+// Use output as input
+document.getElementById('strUseOutput').addEventListener('click', () => {
+  if (!strOutput.value) return;
+  strInput.value = strOutput.value;
+  strOutput.value = '';
+  strCopy.disabled = true;
+  strStats.textContent = '';
+  setStrStatus('Output loaded into input.');
+  updateInputStats();
+  strInput.focus();
+});
+
+// Clear
+document.getElementById('strClear').addEventListener('click', () => {
+  strInput.value = '';
+  strOutput.value = '';
+  strCopy.disabled = true;
+  strInputStats.textContent = '';
+  strStats.textContent = '';
+  setStrStatus('');
+  strInput.focus();
+});
+
+// Copy
+strCopy.addEventListener('click', () => copyText(strOutput.value, strCopy));
+
+// Live input stats
+strInput.addEventListener('input', updateInputStats);


### PR DESCRIPTION
## Summary
- Adds a **String Utilities** tool tab with sort, case convert, and line operations
- Sort lines A→Z, Z→A, or by length
- Case convert: UPPER, lower, Title Case, camelCase, snake\_case, kebab-case
- Line ops: deduplicate, trim whitespace per line, remove blank lines
- Live input stats (lines/words/chars) update as you type
- "Use as Input" button chains operations without copy-paste

## Implementation
- `tools/string.js` — 130 lines, no external deps, pure DOM + string ops
- `splitWords()` handles camelCase, snake\_case, kebab-case, and spaced input uniformly
- camelCase/snake/kebab conversions apply per-line so multi-line text is handled correctly
- Vanilla CSS additions: `.str-ops`, `.str-ops__group`, `.str-ops__label`, `.str-live-stats`

## Test plan
- [ ] Sort A→Z and Z→A produce correct alphabetical order
- [ ] Deduplicate removes only exact duplicates, preserves first occurrence
- [ ] camelCase converts `hello world` → `helloWorld`, `foo-bar` → `fooBar`, `FooBar` → `fooBar`
- [ ] snake\_case and kebab-case handle mixed input (camelCase, spaced, punctuated)
- [ ] Trim removes leading/trailing whitespace per line without collapsing internal spaces
- [ ] Live stats update on input keystroke
- [ ] "Use as Input" chains operations correctly
- [ ] Clear resets both panes and stats
- [ ] Accessible: all buttons labeled, aria-live on status/stats

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)