### PR TITLE
feat(color): add foreground indicator to contrast checker section

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,6 +346,12 @@
                 <span class="pane__label">Contrast Checker</span>
               </div>
               <div class="contrast-pickers">
+                <div class="contrast-fg-indicator" aria-label="Foreground color (from color picker above)">
+                  <span class="contrast-picker-label" id="contrastFgLabel">Foreground</span>
+                  <div class="contrast-fg-swatch" id="contrastFgSwatch" role="img" aria-labelledby="contrastFgLabel"></div>
+                  <output class="contrast-fg-hex" id="contrastFgHex" aria-live="polite" aria-label="Foreground HEX color">—</output>
+                  <span class="contrast-fg-hint">← from picker above</span>
+                </div>
                 <div class="contrast-picker-group">
                   <label class="contrast-picker-label" for="contrastBgPicker">Background</label>
                   <label class="color-picker-wrap contrast-picker-wrap" title="Click to pick background color">

--- a/styles.css
+++ b/styles.css
@@ -885,6 +885,41 @@ main {
   gap: 0.375rem;
 }
 
+.contrast-fg-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.contrast-fg-swatch {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-sm);
+  border: 2px dashed var(--color-border);
+  flex-shrink: 0;
+}
+
+.contrast-fg-hex {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  text-align: center;
+  background: none;
+  border: none;
+  padding: 0;
+  user-select: text;
+}
+
+.contrast-fg-hint {
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  opacity: 0.7;
+  text-align: center;
+  max-width: 7rem;
+  line-height: 1.3;
+}
+
 .contrast-picker-label {
   font-size: 0.72rem;
   font-weight: 600;

--- a/tools/color.js
+++ b/tools/color.js
@@ -13,6 +13,8 @@ const tabColorSwatch = document.getElementById('tabColorSwatch');
 const contrastBgPicker = document.getElementById('contrastBgPicker');
 const contrastBgSwatch = document.getElementById('contrastBgSwatch');
 const contrastBgHex    = document.getElementById('contrastBgHex');
+const contrastFgSwatch = document.getElementById('contrastFgSwatch');
+const contrastFgHex    = document.getElementById('contrastFgHex');
 const contrastPreview  = document.getElementById('contrastPreview');
 const contrastRatio    = document.getElementById('contrastRatio');
 
@@ -222,6 +224,9 @@ function calcContrastRatio(hex1, hex2) {
 function updateContrast() {
   const fgHex = colorPicker.value;
   const bgHex = contrastBgPicker.value;
+
+  contrastFgSwatch.style.background = fgHex;
+  contrastFgHex.value = fgHex.toUpperCase();
 
   contrastPreview.style.backgroundColor = bgHex;
   contrastPreview.style.color = fgHex;


### PR DESCRIPTION
## Summary

The WCAG contrast checker (PR #70) uses the main color picker as foreground input but shows nothing in that section to communicate this. First-time users see only a Background picker and a ratio — the foreground source is invisible.

This PR adds a read-only foreground swatch inside the Contrast Checker section that mirrors the main color picker value in real time.

## Changes

- `index.html`: adds `.contrast-fg-indicator` group before the Background picker — dashed-border swatch + hex output + "← from picker above" hint
- `tools/color.js`: wires `contrastFgSwatch` and `contrastFgHex` into `updateContrast()` so they track `colorPicker.value`
- `styles.css`: `.contrast-fg-indicator`, `.contrast-fg-swatch` (dashed border signals read-only), `.contrast-fg-hex`, `.contrast-fg-hint`

## Acceptance Criteria

- [x] Contrast section shows a small read-only foreground swatch mirroring the main picker
- [x] Swatch has accessible label ("Foreground color (from color picker above)")
- [x] Hint text "← from picker above" clarifies the input source
- [x] No new interactive element — main picker remains single source of truth
- [x] Zero regressions to contrast math or badge logic

## Notes

Stacks on `beta/issue-64-wcag-contrast` (PR #70) since this section does not exist on main yet. Merge #70 first, then this lands cleanly.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)