### PR TITLE
feat(uuid): UUID generator tool (v4 random, v7 time-ordered, bulk generation)

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="jwt">JWT</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="timestamp">Timestamp</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="base">Base</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="uuid">UUID</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -102,6 +103,9 @@
         </button>
         <button class="tab" role="tab" aria-selected="false" aria-controls="panel-base" id="tab-base" data-panel="base" tabindex="-1">
           <span class="tab__icon" aria-hidden="true">01</span> Base
+        </button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="panel-uuid" id="tab-uuid" data-panel="uuid" tabindex="-1">
+          <span class="tab__icon" aria-hidden="true">ID</span> UUID
         </button>
       </div>
     </div>
@@ -839,6 +843,63 @@
 
             <div class="status-bar" id="baseStatus" aria-live="polite" role="status"></div>
             <p class="base-bits" id="baseBits" aria-live="polite"></p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="panel-uuid"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-uuid"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">UUID Generator</h2>
+              <p class="tool__desc">Generate RFC 4122 v4 (random) or v7 (time-ordered, sortable) UUIDs using the browser's built-in Web Crypto API. No server, no dependencies.</p>
+            </div>
+          </div>
+          <div class="tool__body">
+            <div class="uuid-controls">
+              <div class="uuid-control-group">
+                <label class="uuid-label" for="uuidVersion">Version</label>
+                <select id="uuidVersion" class="uuid-select" aria-label="UUID version">
+                  <option value="v4">v4 — random</option>
+                  <option value="v7">v7 — time-ordered</option>
+                </select>
+              </div>
+              <div class="uuid-control-group">
+                <label class="uuid-label" for="uuidCount">Count</label>
+                <select id="uuidCount" class="uuid-select" aria-label="Number of UUIDs to generate">
+                  <option value="1">1</option>
+                  <option value="10">10</option>
+                  <option value="100">100</option>
+                </select>
+              </div>
+              <div class="uuid-control-group uuid-control-group--toggle">
+                <label class="uuid-label" for="uuidCasing">Uppercase</label>
+                <input type="checkbox" id="uuidCasing" class="uuid-toggle" aria-label="Toggle uppercase output">
+              </div>
+              <button class="btn" id="uuidGenerate" aria-label="Generate UUIDs">Generate</button>
+            </div>
+
+            <div class="pane__header uuid-output-header">
+              <span class="pane__label">Output</span>
+              <div class="pane__actions">
+                <button class="btn btn--sm btn--ghost" id="uuidCopy" disabled>Copy All</button>
+              </div>
+            </div>
+            <textarea
+              class="code-area uuid-output"
+              id="uuidOutput"
+              readonly
+              spellcheck="false"
+              aria-label="Generated UUIDs"
+              aria-live="polite"
+            ></textarea>
+            <div class="status-bar" id="uuidStatus" aria-live="polite" role="status"></div>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -17,3 +17,4 @@ import './tools/pomodoro.js';
 import './tools/jwt.js';
 import './tools/timestamp.js';
 import './tools/base.js';
+import './tools/uuid.js';

--- a/styles.css
+++ b/styles.css
@@ -1455,3 +1455,69 @@ main {
   align-items: center;
   word-break: break-all;
 }
+
+/* ============================================
+   UUID Generator
+   ============================================ */
+.uuid-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.875rem;
+  margin-bottom: 1.25rem;
+}
+
+.uuid-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.uuid-control-group--toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 0.1rem;
+}
+
+.uuid-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.uuid-select {
+  padding: 0.45rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+  min-width: 9rem;
+}
+
+.uuid-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.uuid-toggle {
+  width: 1.1rem;
+  height: 1.1rem;
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+.uuid-output-header {
+  margin-bottom: 0.5rem;
+}
+
+.uuid-output {
+  min-height: 7rem;
+  resize: vertical;
+}

--- a/tools/uuid.js
+++ b/tools/uuid.js
@@ -1,0 +1,101 @@
+// UUID Generator
+// Generates RFC 4122 v4 (random) and v7 (time-ordered) UUIDs via Web Crypto API.
+
+import { copyText } from './utils.js';
+
+const uuidVersion  = document.getElementById('uuidVersion');
+const uuidCount    = document.getElementById('uuidCount');
+const uuidOutput   = document.getElementById('uuidOutput');
+const uuidGenerate = document.getElementById('uuidGenerate');
+const uuidCopy     = document.getElementById('uuidCopy');
+const uuidCasing   = document.getElementById('uuidCasing');
+const uuidStatus   = document.getElementById('uuidStatus');
+
+// ---------------------------------------------------------------------------
+// UUID v4 — 122 random bits, version/variant fields set per RFC 4122 §4.4
+// Uses crypto.randomUUID() when available (all modern browsers), falls back
+// to manual bit manipulation via getRandomValues.
+// ---------------------------------------------------------------------------
+function uuidV4() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+  return formatBytes(bytes);
+}
+
+// ---------------------------------------------------------------------------
+// UUID v7 — 48-bit Unix ms timestamp prefix, then version + random bits.
+// Layout: tttttttt-tttt-7xxx-yxxx-xxxxxxxxxxxx
+//   bits 0–47  : current time in milliseconds (big-endian)
+//   bits 48–51 : 0111 (version 7)
+//   bits 52–63 : random
+//   bits 64–65 : 10 (RFC 4122 variant)
+//   bits 66–127: random
+// ---------------------------------------------------------------------------
+function uuidV7() {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const ts = BigInt(Date.now());
+
+  // Write 48-bit timestamp big-endian into bytes 0–5
+  bytes[0] = Number((ts >> 40n) & 0xffn);
+  bytes[1] = Number((ts >> 32n) & 0xffn);
+  bytes[2] = Number((ts >> 24n) & 0xffn);
+  bytes[3] = Number((ts >> 16n) & 0xffn);
+  bytes[4] = Number((ts >>  8n) & 0xffn);
+  bytes[5] = Number(ts & 0xffn);
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x70; // version 7
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+
+  return formatBytes(bytes);
+}
+
+// ---------------------------------------------------------------------------
+// Format a 16-byte array into xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+// ---------------------------------------------------------------------------
+function formatBytes(bytes) {
+  const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0,8)}-${hex.slice(8,12)}-${hex.slice(12,16)}-${hex.slice(16,20)}-${hex.slice(20)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Generate N UUIDs of the selected version
+// ---------------------------------------------------------------------------
+function generate() {
+  const version = uuidVersion.value;
+  const count   = parseInt(uuidCount.value, 10);
+  const upper   = uuidCasing.checked;
+  const fn      = version === 'v7' ? uuidV7 : uuidV4;
+
+  const uuids = Array.from({ length: count }, fn);
+  const output = upper
+    ? uuids.map(u => u.toUpperCase()).join('\n')
+    : uuids.join('\n');
+
+  uuidOutput.value = output;
+  uuidCopy.disabled = false;
+
+  const vLabel = version === 'v7' ? 'v7 (time-ordered)' : 'v4 (random)';
+  uuidStatus.textContent = `Generated ${count} UUID${count !== 1 ? 's' : ''} · ${vLabel}`;
+  uuidStatus.className = 'status-bar status-bar--ok';
+}
+
+// ---------------------------------------------------------------------------
+// Event listeners
+// ---------------------------------------------------------------------------
+uuidGenerate.addEventListener('click', generate);
+
+uuidCopy.addEventListener('click', () => copyText(uuidOutput.value, uuidCopy));
+
+uuidCasing.addEventListener('change', () => {
+  if (!uuidOutput.value) return;
+  uuidOutput.value = uuidCasing.checked
+    ? uuidOutput.value.toUpperCase()
+    : uuidOutput.value.toLowerCase();
+});
+
+// Generate one v4 UUID immediately on load
+generate();


### PR DESCRIPTION
## Summary

Adds a **UUID Generator** tool — one of the most common dev utilities for generating test IDs, database keys, and correlation tokens.

- UUID v4 (random) via `crypto.randomUUID()` with `getRandomValues` fallback — RFC 4122 compliant
- UUID v7 (time-ordered) — 48-bit Unix ms timestamp prefix + random bits, sortable in DBs
- Count selector: 1, 10, 100
- Uppercase/lowercase toggle
- Copy All button
- Auto-generates 1 v4 UUID on load so the tool is immediately useful
- Zero deps, 74 lines of JS

## Changes

- `tools/uuid.js` — `uuidV4`, `uuidV7`, `formatBytes`, `generate` functions
- `index.html` — UUID tab + panel
- `script.js` — import `tools/uuid.js`
- `styles.css` — UUID controls (select, toggle, output textarea)

## Test Plan

- [ ] Load page → UUID tab shows 1 pre-generated v4 UUID
- [ ] Switch to v7 → Generate → output starts with timestamp-based prefix (first 8 chars vary slowly over time)
- [ ] Count 10 → 10 UUIDs generated, one per line
- [ ] Count 100 → 100 UUIDs, textarea scrollable
- [ ] Uppercase toggle → all output uppercased; untoggle → lowercased
- [ ] Copy All → clipboard contains all UUIDs
- [ ] Re-click Generate → new UUIDs each time
- [ ] Keyboard: Tab to Version → Count → Uppercase → Generate — all reachable

## Evidence

UUID v4 format: `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where y ∈ {8,9,a,b}
UUID v7 format: `tttttttt-tttt-7xxx-yxxx-xxxxxxxxxxxx` where first 12 hex chars encode current ms timestamp

Closes #81