### PR TITLE
feat(regex): add replace mode with backreference support

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,34 @@
                 </div>
               </div>
             </div>
+
+            <!-- Replace mode -->
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Replace</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="regexReplaceCopy" disabled>Copy</button>
+                </div>
+              </div>
+              <input
+                type="text"
+                id="regexReplaceTemplate"
+                class="base-input regex-replace-template"
+                placeholder="Replacement template — $1, $2, $&amp;, $`, $' — empty removes matches"
+                spellcheck="false"
+                autocomplete="off"
+                aria-label="Replacement template"
+              >
+              <textarea
+                class="code-area"
+                id="regexReplaceOutput"
+                readonly
+                spellcheck="false"
+                aria-label="Replace result"
+                aria-live="polite"
+                placeholder="Result will appear here…"
+              ></textarea>
+            </div>
           </div>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -722,6 +722,13 @@ main {
 
 .match-empty--error { color: var(--color-danger); opacity: 1; }
 
+.regex-replace-template {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
 /* ============================================
    Color tool
    ============================================ */

--- a/tools/regex.js
+++ b/tools/regex.js
@@ -2,16 +2,24 @@
 
 import { escapeHtml } from './utils.js';
 
-const regexPattern   = document.getElementById('regexPattern');
-const regexFlags     = document.getElementById('regexFlags');
-const regexText      = document.getElementById('regexText');
-const regexStatus    = document.getElementById('regexStatus');
-const regexMatchCount = document.getElementById('regexMatchCount');
-const matchListBody  = document.getElementById('matchListBody');
+const regexPattern         = document.getElementById('regexPattern');
+const regexFlags           = document.getElementById('regexFlags');
+const regexText            = document.getElementById('regexText');
+const regexStatus          = document.getElementById('regexStatus');
+const regexMatchCount      = document.getElementById('regexMatchCount');
+const matchListBody        = document.getElementById('matchListBody');
+const regexReplaceTemplate = document.getElementById('regexReplaceTemplate');
+const regexReplaceOutput   = document.getElementById('regexReplaceOutput');
+const regexReplaceCopy     = document.getElementById('regexReplaceCopy');
 
 function setRegexStatus(msg, type = '') {
   regexStatus.textContent = msg;
   regexStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
+}
+
+function clearReplace() {
+  regexReplaceOutput.value = '';
+  regexReplaceCopy.disabled = true;
 }
 
 function runRegex() {
@@ -24,6 +32,7 @@ function runRegex() {
     matchListBody.innerHTML = '<p class="match-empty">Enter a pattern and test string to see matches.</p>';
     setRegexStatus('');
     regexText.classList.remove('has-matches', 'no-matches');
+    clearReplace();
     return;
   }
 
@@ -36,6 +45,7 @@ function runRegex() {
     matchListBody.innerHTML = `<p class="match-empty match-empty--error">${escapeHtml(String(err))}</p>`;
     setRegexStatus(String(err), 'error');
     regexText.classList.remove('has-matches', 'no-matches');
+    clearReplace();
     return;
   }
 
@@ -43,8 +53,15 @@ function runRegex() {
     regexMatchCount.textContent = '';
     matchListBody.innerHTML = '<p class="match-empty">Enter a test string above.</p>';
     regexText.classList.remove('has-matches', 'no-matches');
+    clearReplace();
     return;
   }
+
+  // Replace mode — runs regardless of match count
+  // Use user's exact flags (without forced 'g') so g/no-g replaces all/first
+  const replaceRx = new RegExp(pattern, flags);
+  regexReplaceOutput.value = text.replace(replaceRx, regexReplaceTemplate.value);
+  regexReplaceCopy.disabled = false;
 
   const matches = [...text.matchAll(rx)];
 
@@ -108,3 +125,12 @@ function scheduleRegex() {
 regexPattern.addEventListener('input', scheduleRegex);
 regexFlags.addEventListener('input', scheduleRegex);
 regexText.addEventListener('input', scheduleRegex);
+regexReplaceTemplate.addEventListener('input', scheduleRegex);
+
+regexReplaceCopy.addEventListener('click', () => {
+  if (!regexReplaceOutput.value) return;
+  navigator.clipboard.writeText(regexReplaceOutput.value).then(() => {
+    regexReplaceCopy.textContent = 'Copied!';
+    setTimeout(() => { regexReplaceCopy.textContent = 'Copy'; }, 1500);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Replace** section below the match list in the Regex Tester
- Template input supports `$1`, `$2`, `$&`, `` $` ``, `$'` backreferences natively via `String.prototype.replace`
- Result updates live as pattern, flags, test string, or template changes
- Copy button with feedback — disabled until there's output
- Replace output appears whether or not there are matches (no matches → original string unchanged)

Closes #90

Author: Beta

## Evidence

Example flow:
1. Pattern: `(\w+)@(\w+)\.(\w+)` | Flags: `g` | Test: `foo@bar.com baz@qux.io`
2. Template: `[$1 at $2 dot $3]`
3. Result: `[foo at bar dot com] [baz at qux dot io]`

All backreferences (`$1`, `$&`, `` $` ``, `$'`) are handled natively by JS — zero custom parsing needed.

## Checklist

- [x] Tests: vanilla JS, no test runner needed — logic is browser native
- [x] No secrets in diff
- [x] Issue linked (#90)
- [x] Accessible: Copy button has disabled state, result area has aria-live
- [x] Mobile-first: Replace section uses existing `tool__pane` layout