### PR TITLE
feat(regex): inline match highlighting with cycling colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,19 @@
                 </div>
               </div>
             </div>
+
+            <!-- Inline highlight output -->
+            <div class="tool__pane tool__pane--full" id="regexHighlightPane" hidden>
+              <div class="pane__header">
+                <span class="pane__label">Highlighted</span>
+              </div>
+              <div
+                class="highlight-output"
+                id="regexHighlight"
+                aria-live="polite"
+                aria-label="Test string with matches highlighted"
+              ></div>
+            </div>
           </div>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -722,6 +722,33 @@ main {
 
 .match-empty--error { color: var(--color-danger); opacity: 1; }
 
+.tool__pane--full { grid-column: 1 / -1; }
+
+.highlight-output {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0.75rem;
+  min-height: 3rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+/* Cycling highlight colors — 4 hues, work on light + dark */
+.highlight-output mark {
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+.hl-0 { background: rgba(250, 204,  21, 0.45); } /* yellow  */
+.hl-1 { background: rgba( 52, 211, 153, 0.45); } /* emerald */
+.hl-2 { background: rgba(167, 139, 250, 0.45); } /* violet  */
+.hl-3 { background: rgba(251, 146,  60, 0.45); } /* orange  */
+
 /* ============================================
    Color tool
    ============================================ */

--- a/tools/regex.js
+++ b/tools/regex.js
@@ -2,16 +2,43 @@
 
 import { escapeHtml } from './utils.js';
 
-const regexPattern   = document.getElementById('regexPattern');
-const regexFlags     = document.getElementById('regexFlags');
-const regexText      = document.getElementById('regexText');
-const regexStatus    = document.getElementById('regexStatus');
+const regexPattern    = document.getElementById('regexPattern');
+const regexFlags      = document.getElementById('regexFlags');
+const regexText       = document.getElementById('regexText');
+const regexStatus     = document.getElementById('regexStatus');
 const regexMatchCount = document.getElementById('regexMatchCount');
-const matchListBody  = document.getElementById('matchListBody');
+const matchListBody   = document.getElementById('matchListBody');
+const regexHighlight  = document.getElementById('regexHighlight');
+const regexHighlightPane = document.getElementById('regexHighlightPane');
 
 function setRegexStatus(msg, type = '') {
   regexStatus.textContent = msg;
   regexStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
+}
+
+function clearHighlight() {
+  regexHighlight.innerHTML = '';
+  regexHighlightPane.hidden = true;
+}
+
+function buildHighlight(text, matches) {
+  let html = '';
+  let cursor = 0;
+  matches.forEach((m, i) => {
+    const start = m.index;
+    const end   = start + m[0].length;
+    // Append unmatched text before this match
+    if (start > cursor) {
+      html += escapeHtml(text.slice(cursor, start));
+    }
+    // Skip zero-length matches (e.g. /a*/g on non-a chars) to avoid empty marks
+    if (m[0].length > 0) {
+      html += `<mark class="hl-${i % 4}">${escapeHtml(m[0])}</mark>`;
+    }
+    cursor = Math.max(cursor, end);
+  });
+  html += escapeHtml(text.slice(cursor));
+  return html;
 }
 
 function runRegex() {
@@ -24,6 +51,7 @@ function runRegex() {
     matchListBody.innerHTML = '<p class="match-empty">Enter a pattern and test string to see matches.</p>';
     setRegexStatus('');
     regexText.classList.remove('has-matches', 'no-matches');
+    clearHighlight();
     return;
   }
 
@@ -36,6 +64,7 @@ function runRegex() {
     matchListBody.innerHTML = `<p class="match-empty match-empty--error">${escapeHtml(String(err))}</p>`;
     setRegexStatus(String(err), 'error');
     regexText.classList.remove('has-matches', 'no-matches');
+    clearHighlight();
     return;
   }
 
@@ -43,6 +72,7 @@ function runRegex() {
     regexMatchCount.textContent = '';
     matchListBody.innerHTML = '<p class="match-empty">Enter a test string above.</p>';
     regexText.classList.remove('has-matches', 'no-matches');
+    clearHighlight();
     return;
   }
 
@@ -53,6 +83,7 @@ function runRegex() {
     matchListBody.innerHTML = '<p class="match-empty">No matches found.</p>';
     regexText.classList.remove('has-matches');
     regexText.classList.add('no-matches');
+    clearHighlight();
     return;
   }
 
@@ -97,6 +128,10 @@ function runRegex() {
 
   matchListBody.innerHTML = '';
   matchListBody.appendChild(frag);
+
+  // Inline highlight
+  regexHighlight.innerHTML = buildHighlight(text, matches);
+  regexHighlightPane.hidden = false;
 }
 
 let regexDebounce;


### PR DESCRIPTION
## Summary

- Adds a **Highlighted** pane below the match list in the Regex Tester
- Renders the test string with each match wrapped in `<mark>` tags — users see matches **in context**, not just as a position list
- 4 cycling colors (yellow, emerald, violet, orange) distinguish consecutive matches visually
- Pane is hidden when there are no matches or no pattern; clears on regex error

## Implementation

`buildHighlight(text, matches)` walks matches left→right:
1. `escapeHtml()` on all raw text before injecting marks — no XSS risk
2. Zero-length matches (e.g. `/a*/g` on non-`a` chars) are skipped to avoid empty `<mark>` spans
3. `cursor = Math.max(cursor, end)` guards against any overlapping match edge cases from matchAll
4. `white-space: pre-wrap` on the output div preserves newlines in multiline test strings
5. 4 `rgba`-based colors (0.45 alpha) render correctly on both light and dark themes

## Evidence

Example:
- Pattern: `\b\w+@\w+\.\w+\b` | Flags: `g` | Test: `foo@bar.com, hello@world.org, not-an-email`
- Highlighted pane shows the full string with `foo@bar.com` and `hello@world.org` marked in alternating colors, `not-an-email` unmarked

Closes #91

Author: Beta