### PR TITLE
feat(html): HTML entity encoder/decoder tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="jwt">JWT</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="timestamp">Timestamp</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="base">Base</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="htmlentity">HTML Entity</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -102,6 +103,9 @@
         </button>
         <button class="tab" role="tab" aria-selected="false" aria-controls="panel-base" id="tab-base" data-panel="base" tabindex="-1">
           <span class="tab__icon" aria-hidden="true">01</span> Base
+        </button>
+        <button class="tab" role="tab" aria-selected="false" aria-controls="panel-htmlentity" id="tab-htmlentity" data-panel="htmlentity" tabindex="-1">
+          <span class="tab__icon" aria-hidden="true">&amp;</span> HTML Entity
         </button>
       </div>
     </div>
@@ -890,6 +894,64 @@
 
             <div class="status-bar" id="baseStatus" aria-live="polite" role="status"></div>
             <p class="base-bits" id="baseBits" aria-live="polite"></p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════════════════════════
+           HTML Entity Encoder / Decoder
+           ═══════════════════════════════ -->
+      <section
+        id="panel-htmlentity"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-htmlentity"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">HTML Entity Encoder / Decoder</h2>
+              <p class="tool__desc">Escape special characters to HTML entities (<code>&amp;amp;</code> <code>&amp;lt;</code> <code>&amp;gt;</code> <code>&amp;quot;</code> <code>&amp;#39;</code>), or decode any entity — named, decimal, or hex — back to plain text.</p>
+            </div>
+          </div>
+          <div class="tool__body tool__body--split">
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Input</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm" id="heEncode">Encode →</button>
+                  <button class="btn btn--sm btn--secondary" id="heDecode">← Decode</button>
+                  <button class="btn btn--sm btn--ghost" id="heClear">Clear</button>
+                </div>
+              </div>
+              <textarea
+                class="code-area"
+                id="heInput"
+                placeholder="Enter plain text to encode, or HTML with entities to decode…"
+                spellcheck="false"
+                autocomplete="off"
+                aria-label="HTML entity input"
+              ></textarea>
+              <div class="status-bar" id="heStatus" aria-live="polite" role="status"></div>
+            </div>
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">Output</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="heCopy" disabled>Copy</button>
+                  <button class="btn btn--sm btn--ghost" id="heSwap" title="Swap input ↔ output">⇄ Swap</button>
+                </div>
+              </div>
+              <textarea
+                class="code-area"
+                id="heOutput"
+                placeholder="Result will appear here…"
+                readonly
+                spellcheck="false"
+                aria-label="HTML entity output"
+              ></textarea>
+            </div>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -17,3 +17,4 @@ import './tools/pomodoro.js';
 import './tools/jwt.js';
 import './tools/timestamp.js';
 import './tools/base.js';
+import './tools/htmlentity.js';

--- a/tools/htmlentity.js
+++ b/tools/htmlentity.js
@@ -1,0 +1,72 @@
+// HTML Entity Encoder / Decoder
+
+import { copyText } from './utils.js';
+
+const heInput  = document.getElementById('heInput');
+const heOutput = document.getElementById('heOutput');
+const heStatus = document.getElementById('heStatus');
+const heCopy   = document.getElementById('heCopy');
+
+function setStatus(msg, type = '') {
+  heStatus.textContent = msg;
+  heStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
+}
+
+// Encode the 5 HTML special characters to named entities.
+// & must be first to avoid double-encoding.
+function encodeEntities(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Decode all HTML entities (named, decimal, hex) via DOMParser.
+// textContent extraction is XSS-safe — we never touch innerHTML of the live DOM.
+function decodeEntities(str) {
+  const doc = new DOMParser().parseFromString(
+    `<!DOCTYPE html><html><body>${str}</body></html>`,
+    'text/html'
+  );
+  return doc.body.textContent;
+}
+
+document.getElementById('heEncode').addEventListener('click', () => {
+  const text = heInput.value;
+  if (!text) { setStatus('Nothing to encode.', 'error'); return; }
+  const encoded = encodeEntities(text);
+  heOutput.value = encoded;
+  heCopy.disabled = false;
+  const changed = (encoded.length - text.length);
+  const sign = changed > 0 ? '+' : '';
+  setStatus(`Encoded · ${text.length} chars → ${encoded.length} chars (${sign}${changed})`, 'ok');
+});
+
+document.getElementById('heDecode').addEventListener('click', () => {
+  const text = heInput.value.trim();
+  if (!text) { setStatus('Nothing to decode.', 'error'); return; }
+  const decoded = decodeEntities(text);
+  heOutput.value = decoded;
+  heCopy.disabled = false;
+  setStatus(`Decoded · ${text.length} chars → ${decoded.length} chars`, 'ok');
+});
+
+document.getElementById('heClear').addEventListener('click', () => {
+  heInput.value = '';
+  heOutput.value = '';
+  heCopy.disabled = true;
+  setStatus('');
+  heInput.focus();
+});
+
+heCopy.addEventListener('click', () => copyText(heOutput.value, heCopy));
+
+document.getElementById('heSwap').addEventListener('click', () => {
+  const tmp = heInput.value;
+  heInput.value = heOutput.value;
+  heOutput.value = tmp;
+  heCopy.disabled = !heOutput.value;
+  setStatus('Swapped.');
+});


### PR DESCRIPTION
## Summary

Adds an **HTML Entity Encoder / Decoder** tool — paste raw text to get HTML-escaped output, or paste HTML with entities (named, decimal `&#NNN;`, hex `&#xNN;`) to decode back to plain text.

Author: Alpha

Closes #111

## What's included

- `tools/htmlentity.js` — encoder/decoder module, following existing tool patterns
- `index.html` — tab button (`&amp;` icon) + full panel with input/output textareas, encode/decode/clear/copy/swap controls
- `script.js` — module import

## Implementation details

**Encoding** — ordered replacements prevent double-encoding:
```js
str.replace(/&/g, '&amp;')   // & first
   .replace(/</g, '&lt;')
   .replace(/>/g, '&gt;')
   .replace(/"/g, '&quot;')
   .replace(/'/g, '&#39;')
```

**Decoding** — DOMParser delegates to the browser's full HTML5 entity set:
```js
const doc = new DOMParser().parseFromString(
  `<!DOCTYPE html><html><body>${str}</body></html>`,
  'text/html'
);
return doc.body.textContent;  // XSS-safe: parsed doc never touches live DOM
```
`doc.body.textContent` (not `documentElement`) correctly scopes extraction to the body content only.

## Evidence

Tested manually:
- Encode: `<script>alert("XSS")</script>` → `&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;` ✓
- Encode: `Tom & Jerry's` → `Tom &amp; Jerry&#39;s` ✓  
- Decode: `&lt;strong&gt;Hello &amp; World&lt;/strong&gt;` → `<strong>Hello & World</strong>` ✓
- Decode: `&#60;&#62;` (decimal) → `<>` ✓
- Decode: `&#x3C;&#x3E;` (hex) → `<>` ✓
- Swap button: exchanges input/output ✓
- Empty input: shows error state ✓
- Keyboard nav: Tab through all controls, Space/Enter activate buttons ✓
- aria-live on status bar announces updates to screen readers ✓
- No regressions in JSON, Base64, URL, JWT tools ✓

## Checklist

- [x] Page loads without JS errors
- [x] Feature works end-to-end (happy path)
- [x] Edge cases handled (empty, special chars, decimal/hex entities)
- [x] Error states show helpful messages
- [x] Keyboard accessible
- [x] Follows existing code patterns
- [x] No regressions in existing tools