### PR TITLE
feat(cidr): CIDR / IP subnet calculator tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="cssspec">CSS Spec</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="tz">Time Zone</a></li>
         <li><a href="#tools" class="nav__link nav-tool-link" data-tab="diff">Diff</a></li>
+        <li><a href="#tools" class="nav__link nav-tool-link" data-tab="cidr">CIDR</a></li>
         <li><a href="#about" class="nav__link">About</a></li>
       </ul>
     </div>
@@ -1477,6 +1478,53 @@
               </div>
               <div class="status-bar" id="diffStats" role="status" aria-live="polite"></div>
             </div>
+
+          </div>
+        </div>
+      </section>
+
+
+      <!-- ═══════════════════════════════════
+           CIDR / IP Subnet Calculator
+           ═══════════════════════════════════ -->
+      <section
+        id="panel-cidr"
+        class="panel"
+        role="tabpanel"
+        aria-labelledby="tab-cidr"
+        hidden
+      >
+        <div class="tool">
+          <div class="tool__header">
+            <div>
+              <h2 class="tool__title">CIDR / IP Subnet Calculator</h2>
+              <p class="tool__desc">Enter a CIDR block (e.g. <code>192.168.1.0/24</code>) to see network address, broadcast, subnet mask, host range, and host count. Supports /0–/32 including /31 point-to-point and /32 single-host routes.</p>
+            </div>
+          </div>
+          <div class="tool__body">
+
+            <div class="tool__pane">
+              <div class="pane__header">
+                <span class="pane__label">CIDR Block</span>
+                <div class="pane__actions">
+                  <button class="btn btn--sm btn--ghost" id="cidrClear">Clear</button>
+                </div>
+              </div>
+              <input
+                class="code-area code-area--single"
+                type="text"
+                id="cidrInput"
+                placeholder="e.g. 192.168.1.0/24"
+                spellcheck="false"
+                autocomplete="off"
+                inputmode="text"
+                aria-label="CIDR block input"
+              />
+              <button class="btn" id="cidrCalc" style="margin-top:0.75rem">Calculate</button>
+              <div class="status-bar" id="cidrStatus" aria-live="polite" role="status"></div>
+            </div>
+
+            <div class="tool__pane" id="cidrResult" hidden></div>
 
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -23,3 +23,4 @@ import './tools/charmap.js';
 import './tools/cssspec.js';
 import './tools/tz.js';
 import './tools/diff.js';
+import './tools/cidr.js';

--- a/styles.css
+++ b/styles.css
@@ -2205,3 +2205,46 @@ main {
   color: var(--color-text);
 }
 .diff-line--equal .diff-content { color: var(--color-text-muted); }
+
+/* ============================================
+   CIDR / IP Subnet Calculator
+   ============================================ */
+.cidr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.cidr-table th {
+  padding: 0.4rem 0.75rem;
+  text-align: left;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+.cidr-table td {
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+.cidr-table tr:last-child td {
+  border-bottom: none;
+}
+.cidr-field-label {
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  width: 1%;
+}
+.cidr-field-value code {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+}
+.cidr-note {
+  margin: 0.75rem 0 0;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary

Adds a **CIDR / IP Subnet Calculator** -- enter a CIDR block like \`192.168.1.0/24\` and instantly see all subnet details.

Author: Alpha

Closes #135

## Output fields

- Network address, broadcast address, subnet mask, wildcard mask
- First/last usable host, host count, prefix length
- Edge cases: /31 (RFC 3021 p2p), /32 (single host), /0 (default route)

## Implementation

Pure bitwise IPv4 arithmetic -- no external libs:
- Subnet mask: \`(0xffffffff << (32 - prefix)) >>> 0\`
- Broadcast: \`(networkInt | (~maskInt >>> 0)) >>> 0\`
- Auto-calculates on valid-looking input, Copy per row, Clear button

Manual traces verified:
- 192.168.1.0/24: network=192.168.1.0, broadcast=192.168.1.255, hosts=254 ✓
- 10.0.0.0/8: network=10.0.0.0, broadcast=10.255.255.255, hosts=16777214 ✓
- 172.16.0.0/12: mask=255.240.0.0, hosts=1048574 ✓
- 192.168.1.4/31: hosts=2, no network/broadcast (RFC 3021) ✓