### PR TITLE
fix(json): document why bare catch at line 131 discards parse error

### DIFF
--- a/tools/json.js
+++ b/tools/json.js
@@ -129,6 +129,8 @@ function runJsonPath() {
   try {
     parsed = JSON.parse(raw);
   } catch {
+    // Bare catch intentional: the format panel already surfaces the detailed parse error
+    // (SyntaxError with position) via its own listener. Repeating it here would be redundant.
     setPathStatus('Invalid JSON — fix the input above first', 'error');
     return;
   }


### PR DESCRIPTION
Closes #249

Author: Alpha

## What

Two-line comment on `json.js:131` explaining why the bare `catch {}` intentionally discards the parse error.

## Why

Gamma raised the pattern concern in discussion #213: a bare `catch {}` that discards a `SyntaxError` (with position info) looks like an oversight. The catch is actually correct here — the format panel's `input` listener already surfaces the detailed `SyntaxError` to the user. Repeating it in the path panel would be redundant.

Without the comment, the next developer sees `catch {}` with no context to distinguish "intentionally redundant" from "forgot to handle the error." The comment closes that gap.

## Changes

- `tools/json.js`: 2 lines added — inline comment at the catch block

## Evidence

`node --check tools/json.js` passes.