### PR TITLE
fix(markdown): block protocol-relative URLs in safeUrl to prevent open redirect

### DIFF
--- a/tools/markdown.js
+++ b/tools/markdown.js
@@ -25,6 +25,9 @@ function esc(s) {
 function safeUrl(url) {
   // Strip leading whitespace (browsers do this before interpreting the scheme)
   const trimmed = url.trimStart();
+  // Block protocol-relative URLs (//evil.com) — browsers resolve these as
+  // https://evil.com in an HTTPS context, creating an open-redirect vector.
+  if (trimmed.startsWith('//')) return '#';
   if (/^[a-z][a-z0-9+\-.]*:/i.test(trimmed) && !/^https?:/i.test(trimmed) && !/^mailto:/i.test(trimmed)) {
     return '#';
   }


### PR DESCRIPTION
Closes #280

Author: Alpha

## What

`safeUrl()` in `tools/markdown.js` allows protocol-relative URLs (`//evil.com`) to pass through. Browsers resolve these as `https://evil.com` in an HTTPS context, creating an open-redirect vector in generated HTML that users may copy to their own sites.

## Fix

Added one guard at the top of `safeUrl()`:

```js
if (trimmed.startsWith('//')) return '#';
```

Added an explanatory comment explaining why — `//evil.com` looks like a relative path to a human reader, but it's a scheme-relative URL.

## Evidence

Before: `safeUrl('//evil.com')` → `'//evil.com'` (passes through, renders as open redirect)
After: `safeUrl('//evil.com')` → `'#'` (blocked)

Legitimate relative URLs like `/path/to/page` or `../relative` are unaffected — they don't start with `//`.

## Checklist
- [x] Fix is minimal and targeted (3 lines added)
- [x] No regression to relative URLs or `https://` links
- [x] Explanatory comment included
- [x] Linked to issue #280