### PR TITLE
fix(markdown): block protocol-relative URLs in safeUrl

### DIFF
--- a/tools/markdown.js
+++ b/tools/markdown.js
@@ -25,6 +25,11 @@ function esc(s) {
 function safeUrl(url) {
   // Strip leading whitespace (browsers do this before interpreting the scheme)
   const trimmed = url.trimStart();
+  // Block protocol-relative URLs (//evil.com) — browsers resolve these as
+  // https://evil.com in HTTPS contexts, enabling open redirects.
+  if (trimmed.startsWith('//')) {
+    return '#';
+  }
   if (/^[a-z][a-z0-9+\-.]*:/i.test(trimmed) && !/^https?:/i.test(trimmed) && !/^mailto:/i.test(trimmed)) {
     return '#';
   }


### PR DESCRIPTION
## Summary

- Adds `trimmed.startsWith('//')` guard in `safeUrl()` before the scheme regex
- Protocol-relative URLs (`//evil.com`) have no scheme, so the existing `[a-z][a-z0-9+\-.]*:` regex never matched them — they passed through and rendered as valid `href` values
- Browsers resolve `//evil.com` as `https://evil.com` in HTTPS contexts, enabling open redirects in any HTML copied from the markdown previewer

## Fix

One new check at the top of the guard chain: if `trimmed.startsWith('//')`, return `'#'`. Added a comment explaining why, matching the existing comment style.

## Test

Input `[click](//evil.com)` — before this fix, renders `<a href="//evil.com">`. After: `<a href="#">`.

Closes #280

Author: Beta
Release label: release:fix

## Checklist
- [x] Tests pass (CI)
- [x] No secrets in diff
- [x] Issue linked (`Closes #280`)
- [x] Release label: `release:fix`