### PR TITLE
a11y(nav): add aria-hidden to mobile nav menu when closed

### DIFF
--- a/tools/nav.js
+++ b/tools/nav.js
@@ -3,9 +3,32 @@
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('navMenu');
 
+// aria-hidden on the menu only applies in mobile (hamburger visible).
+// On desktop the menu is always in the accessibility tree.
+const mobileNav = window.matchMedia('(max-width: 640px)');
+
 function setNavOpen(open) {
   hamburger.setAttribute('aria-expanded', String(open));
+  if (mobileNav.matches) {
+    navMenu.setAttribute('aria-hidden', String(!open));
+  } else {
+    navMenu.removeAttribute('aria-hidden');
+  }
   navMenu.classList.toggle('is-open', open);
+}
+
+// Sync aria-hidden when viewport crosses the mobile breakpoint
+mobileNav.addEventListener('change', () => {
+  if (!mobileNav.matches) {
+    navMenu.removeAttribute('aria-hidden');
+  } else if (hamburger.getAttribute('aria-expanded') !== 'true') {
+    navMenu.setAttribute('aria-hidden', 'true');
+  }
+});
+
+// Initialize: on mobile, menu starts closed
+if (mobileNav.matches) {
+  navMenu.setAttribute('aria-hidden', 'true');
 }
 
 hamburger.addEventListener('click', () => {


### PR DESCRIPTION
Closes #287

Author: Alpha

## What

Adds `aria-hidden` management to the mobile hamburger nav menu so screen readers cannot navigate to tool links when the menu is visually closed.

## Why

`aria-expanded="false"` on the hamburger tells AT the controlled region is collapsed, but per ARIA 1.2 this does not automatically hide the controlled element. The 28 nav links remained in the accessibility tree even when the menu was hidden via CSS transform.

## Changes

**`tools/nav.js`**
- `setNavOpen()` sets `aria-hidden="true/false"` on `navMenu` (mobile viewport only)
- Initialization sets `aria-hidden="true"` on mobile page load (menu starts closed)
- `matchMedia` change listener syncs state at 640px breakpoint: desktop removes `aria-hidden` entirely (nav always visible, always in AT)

## Design decision

The issue suggested `aria-hidden="true"` in static HTML. That's wrong for desktop — it would permanently hide 28 links from AT on wide viewports. Media-query scope (`window.matchMedia('(max-width: 640px)')`) matches the CSS breakpoint exactly.

Note: #286 (hidden on inactive panels) verified already fixed in main — closed without a PR.

## Evidence

- Mobile (≤640px, menu closed): `navMenu[aria-hidden="true"]` ✅
- Mobile (≤640px, menu open): `navMenu[aria-hidden="false"]` ✅
- Desktop (>640px): no `aria-hidden` attribute ✅