### PR TITLE
fix(coordinator): re-escalate P0/P1 issues with no open PR

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -915,6 +915,12 @@ function decideAction(agentKey, ctx, turnCount = 0) {
     const labels = (i.labels || []).map(l => l.name);
     if (!labels.includes('P0-critical') && !labels.includes('P1-high')) return false;
     if (labels.includes('status:blocked')) return false;
+    // Exclude self-assigned issues — those are already handled by myStaleIssues.
+    // This filter targets the case where the issue is assigned to the *peer* and their PR was closed.
+    const assignedToMe = (i.assignees || []).some(a =>
+      a.login?.toLowerCase().includes(agent.name.toLowerCase())
+    );
+    if (assignedToMe) return false;
     const issueRef = new RegExp(`(?<![0-9])#${i.number}(?![0-9])`);
     const hasOpenPR = ctx.openPRs.some(pr =>
       issueRef.test(pr.title || '') || issueRef.test(pr.body || '')


### PR DESCRIPTION
Closes #297

Author: Beta

## Problem

P0/P1 issues assigned to the peer whose PRs are closed without merging fall through both candidate pools:
- `unassigned` skips them: the issue IS assigned (to peer)
- `myStaleIssues` skips them: not assigned to self

Issue #280 was the concrete example — two PRs (#293, #294) closed without merging, the issue sat open for multiple turns with no active PR.

## Changes

**`coordinator.js`** — new candidate block in `decideAction()` Phase 2:

```js
// ── Stranded high-priority issues: P0/P1 open issues with no open PR
const strandedHighPriorityIssues = ctx.openIssues.filter(i => {
  const labels = (i.labels || []).map(l => l.name);
  if (!labels.includes('P0-critical') && !labels.includes('P1-high')) return false;
  if (labels.includes('status:blocked')) return false;
  const hasOpenPR = ctx.openPRs.some(pr =>
    (pr.title || '').includes(`#${i.number}`) || (pr.body || '').includes(`#${i.number}`)
  );
  return !hasOpenPR;
});
```

- Scores with `+20` escalation bonus over standard `implement-issue` scoring
- Logs each stranded issue found for traceability
- Sets `action.escalated = true` — surfaced in the prompt template so the agent knows to check closed PRs

**Prompt template** — adds `[Escalated]` notice when `action.escalated` is true, telling the agent to check closed PRs for prior partial implementations.

## Why scoring (not gating)

Using a scored candidate in Phase 2 (not a hard gate in Phase 1) is the right call:
- A stranded P1 issue scores ~140 (60 base + 60 P1 + 20 escalation), which beats reviewing/merging P3 work (~60–80)
- A stranded P0 scores ~180, beating almost everything
- No ordering bugs possible — it's all math

## Test Plan

- [ ] Current open P0/P1 issues with no open PR (e.g. #280 before PR #296 was opened) would now be picked up as `Stranded P0/P1 issue #280 has no open PR — escalating`
- [ ] Issues with an open PR are NOT stranded (hasOpenPR check filters them)
- [ ] `status:blocked` issues are excluded
- [ ] No duplicate execution: `claimWork` prevents both `unassigned` and `strandedHighPriorityIssues` from claiming the same issue
- [ ] Escalation notice appears in prompt when `action.escalated === true`

⚠️ Requires coordinator restart to take effect.