### PR TITLE
fix(coordinator): exclude reviewer's own comments from re-review bonus

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -832,12 +832,12 @@ function decideAction(agentKey, ctx, turnCount = 0) {
     // Re-review request bonus (+15)
     // Filter to comments NOT authored by the reviewing agent — a reviewer's own note
     // ("I'll re-review when CI passes") should not inflate the score for a PR they
-    // are already handling. Only the PR author requesting re-review should trigger this.
+    // are already handling. Third-party comments (Gamma, owner, etc.) still trigger the bonus.
     const pc = ctx.prConversations.find(c => c.pr === pr.number);
-    const agentLoginPart = agent.name.toLowerCase();
+    const agentLogin = agent.ghUser.toLowerCase();
     if (pc && (pc.comments || []).some(c =>
       RE_REVIEW_PATTERN.test(c.body || '') &&
-      !(c.author?.login || '').toLowerCase().includes(agentLoginPart)
+      !(c.author?.login || '').toLowerCase().includes(agentLogin)
     )) bonus += 15;
     // Stale PR bonus (+10)
     if (isPRStale(pc || pr, staleThresholdMs)) bonus += 10;


### PR DESCRIPTION
Closes #266

Author: Alpha

## Problem

`RE_REVIEW_PATTERN` matched any PR conversation comment containing `re-review`. No author filter meant that when a reviewer left a procedural note like "I'll re-review when CI passes," it inflated the re-review bonus for a PR they were already handling — a false positive.

## Fix

Filter to comments not authored by the reviewing agent. Any commenter who is not the reviewing agent (PR author, Gamma, owner, etc.) can still trigger the +15 bonus — the filter only suppresses the reviewer's own procedural notes.

Uses `agent.ghUser.toLowerCase()` (the actual GitHub login, e.g. `alpha-peer-dev`) for login matching, not `agent.name` (display label `alpha`). These are different fields; `ghUser` is the correct one for `c.author?.login` comparisons.

## Test Plan

- [ ] A peer PR where only the reviewer left a re-review comment does NOT get the +15 bonus
- [ ] A peer PR where the PR author left a re-review request DOES get the +15 bonus
- [ ] A peer PR where Gamma left a re-review comment DOES get the +15 bonus (third-party comment)

⚠️ Requires coordinator restart to take effect.