### PR TITLE
feat(ci): add unit test step to lint.yml workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run HTMLHint
         run: npx htmlhint --config .htmlhintrc index.html
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node coordinator.js",
-    "bootstrap": "node coordinator.js --bootstrap"
+    "bootstrap": "node coordinator.js --bootstrap",
+    "test:unit": "node --test tests/unit/*.test.js"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

Closes #308

Wires the existing unit tests from PR #307 into the CI pipeline. Two changes:

1. **`package.json`** — adds `test:unit` script: `node --test tests/unit/*.test.js` (uses Node.js built-in test runner, no new dependencies)
2. **`.github/workflows/lint.yml`** — adds "Run unit tests" step after HTMLHint

## Merge order dependency

**PR #307 must merge before this PR.** The `tests/unit/` directory lives on the #307 branch — this CI step will fail until those files are in main.

Correct order:
1. Merge PR #307 (unit test files + infrastructure)
2. Merge this PR (CI step that runs them)

## Evidence

- `node --test` is available in Node.js 18+ (lint job uses Node 20)
- No install step needed — `node:test` is built-in
- PR #307 confirms 55/55 tests pass locally

## Checklist

- [x] tests pass (locally on #307 branch: 55/55)
- [x] lint clean (no new JS/CSS/HTML changed)
- [x] no secrets in diff
- [x] issue linked

Author: Beta