### PR TITLE
fix(notes): setNotesStatus uses boolean isError — align to string type API

### DIFF
--- a/tools/notes.js
+++ b/tools/notes.js
@@ -90,9 +90,9 @@ const notesExportBtn = document.getElementById('notesExport');
 const notesImportBtn = document.getElementById('notesImport');
 const notesImportFile = document.getElementById('notesImportFile');
 
-function setNotesStatus(msg, isError) {
+function setNotesStatus(msg, type = '') {
   notesStatus.textContent = msg;
-  notesStatus.className = 'status-bar' + (isError ? ' status-bar--error' : '');
+  notesStatus.className = 'status-bar' + (type ? ` status-bar--${type}` : '');
 }
 
 notesExportBtn.addEventListener('click', () => {
@@ -103,7 +103,7 @@ notesExportBtn.addEventListener('click', () => {
   a.download = 'devtools-notes.json';
   a.click();
   URL.revokeObjectURL(url);
-  setNotesStatus(`Exported ${notes.length} ${notes.length === 1 ? 'note' : 'notes'}.`, false);
+  setNotesStatus(`Exported ${notes.length} ${notes.length === 1 ? 'note' : 'notes'}.`, 'ok');
 });
 
 notesImportBtn.addEventListener('click', () => {
@@ -128,12 +128,12 @@ notesImportFile.addEventListener('change', () => {
       notes = [...newNotes, ...notes];
       saveNotes();
       renderNotes();
-      setNotesStatus(`Imported ${newNotes.length} new ${newNotes.length === 1 ? 'note' : 'notes'} (${imported.length - newNotes.length} duplicate${imported.length - newNotes.length === 1 ? '' : 's'} skipped).`, false);
+      setNotesStatus(`Imported ${newNotes.length} new ${newNotes.length === 1 ? 'note' : 'notes'} (${imported.length - newNotes.length} duplicate${imported.length - newNotes.length === 1 ? '' : 's'} skipped).`, 'ok');
     } catch (err) {
-      setNotesStatus(`Import failed: ${err.message}`, true);
+      setNotesStatus(`Import failed: ${err.message}`, 'error');
     }
   };
-  reader.onerror = () => setNotesStatus('Import failed: could not read file.', true);
+  reader.onerror = () => setNotesStatus('Import failed: could not read file.', 'error');
   reader.readAsText(file);
 });
 


### PR DESCRIPTION
Author: Beta

## Problem

`tools/notes.js` defines `setNotesStatus` with a boolean `isError` parameter instead of the string `type` used by all other tools. Success messages (`export`, `import`) pass `false`, so they render in neutral grey (`status-bar`) rather than green (`status-bar--ok`).

## Fix

- Signature: `setNotesStatus(msg, isError)` → `setNotesStatus(msg, type = '')`
- Body: `(isError ? ' status-bar--error' : '')` → `(type ? \` status-bar--\${type}\` : '')`
- 4 call sites updated: export success → `'ok'`, import success → `'ok'`, import parse error → `'error'`, reader onerror → `'error'`

## Forward-compat note (PR #323)

PR #323 adds a `saveNotes()` catch block using `setNotesStatus('⚠ …', 'error')` — already the string form. No ordering constraint between this PR and #323.

## Evidence

All call sites audited:
- Line 106: export success `false` → `'ok'`
- Line 131: import success `false` → `'ok'`
- Line 133: import parse error `true` → `'error'`
- Line 136: reader onerror `true` → `'error'`

Closes #289