### PR TITLE
fix(cidr): escape all values injected into innerHTML template

### DIFF
--- a/tools/cidr.js
+++ b/tools/cidr.js
@@ -1,7 +1,7 @@
 // CIDR / IP Subnet Calculator
 // Parses CIDR notation and computes network details using bitwise arithmetic.
 
-import { copyText } from './utils.js';
+import { copyText, escapeHtml } from './utils.js';
 
 const cidrInput   = document.getElementById('cidrInput');
 const cidrCalc    = document.getElementById('cidrCalc');
@@ -105,13 +105,13 @@ function calculate() {
       <tbody>
         ${rows.map(r => `
           <tr>
-            <td class="cidr-field-label">${r.label}</td>
-            <td class="cidr-field-value" id="${r.id}"><code>${r.value}</code></td>
-            <td><button class="btn btn--sm btn--ghost cidr-copy-btn" data-value="${r.value}" aria-label="Copy ${r.label}">Copy</button></td>
+            <td class="cidr-field-label">${escapeHtml(r.label)}</td>
+            <td class="cidr-field-value" id="${escapeHtml(r.id)}"><code>${escapeHtml(r.value)}</code></td>
+            <td><button class="btn btn--sm btn--ghost cidr-copy-btn" data-value="${escapeHtml(r.value)}" aria-label="Copy ${escapeHtml(r.label)}">Copy</button></td>
           </tr>`).join('')}
       </tbody>
     </table>
-    ${note ? `<p class="cidr-note">${note}</p>` : ''}
+    ${note ? `<p class="cidr-note">${escapeHtml(note)}</p>` : ''}
   `;
 
   cidrResult.hidden = false;


### PR DESCRIPTION
Author: Alpha

## Problem

`tools/cidr.js` builds a results table via template literal and assigns it to `innerHTML` (line 100–115). Row labels, values, IDs, and the note string are injected without escaping:

```js
// Before — attribute context unescaped
<td class="cidr-field-label">${r.label}</td>
<td ... id="${r.id}"><code>${r.value}</code></td>
<button data-value="${r.value}" aria-label="Copy ${r.label}">
<p class="cidr-note">${note}</p>
```

Current values (IP addresses from `intToIp()`, integers, hardcoded labels) cannot contain HTML-special characters — but the pattern is wrong. Attribute and text-node contexts in an `innerHTML` template must be escaped at the point of insertion.

Closes #292

## Fix

Import `escapeHtml` from `utils.js` and apply it to all injected values: `r.label`, `r.value`, `r.id`, and `note`.

`data-value` is read back via `btn.dataset.value` — the browser HTML-parses attribute values on read, so `&quot;` becomes `"` in `dataset.value`. The copy action is unaffected.

## Evidence

- `escapeHtml` covers `&`, `<`, `>`, `"` — full attribute context safety
- All five injection points patched in one commit (242352c)
- Behaviour unchanged for all current values (IP notation, integers, hardcoded labels contain no HTML-special chars)

## Checklist
- [x] Tests pass (CI)
- [x] No secrets in diff
- [x] Linked to issue