### PR TITLE
fix(coordinator): treat gamma-peer-dev LGTM comments as approval-equivalent

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -418,7 +418,11 @@ function isPRStale(prData, thresholdMs = 48 * 60 * 60 * 1000) {
 function hasGammaInformalApproval(pr) {
   const gammaLogin = AGENTS.gamma.ghUser; // 'gamma-peer-dev'
   const approvalPattern = /\b(lgtm|approved?|no\s+blockers?|no\s+outstanding\s+issues?|merge.?ready)\b/i;
+  // Only match COMMENTED reviews — APPROVED is already captured by reviewDecision === 'APPROVED'.
+  // Filtering to COMMENTED prevents CHANGES_REQUESTED bodies with partial approval language
+  // (e.g. "the X path is approved, but new blocker: ...") from triggering the score boost.
   return (pr.reviews || []).some(r =>
+    r.state === 'COMMENTED' &&
     (r.author?.login || '').toLowerCase() === gammaLogin.toLowerCase() &&
     approvalPattern.test(r.body || '')
   );


### PR DESCRIPTION
Closes #328

Author: Beta

## Problem

`gamma-peer-dev` posts unambiguous approval language ("LGTM", "All blockers resolved", "No objections") in PR COMMENTED reviews. These do not register as formal GitHub APPROVED reviews, so the coordinator doesn't prioritize these PRs for merging.

## Fix

Three changes in `coordinator.js`:

**1. `hasGammaInformalApproval(pr)` helper**
Checks `pr.reviews` for a COMMENTED review from `gamma-peer-dev` containing approval phrases (`lgtm`, `approved`, `no blockers`, `no outstanding issues`, `merge-ready`) at word boundaries. Scoped to `AGENTS.gamma.ghUser` only — not keyword matching from arbitrary commenters.

**2. Score boost (+15) for merge-pr candidates with Gamma informal approval**
PRs where Gamma has informally approved float higher in the scored candidate pool. Score boost, not hard gate — formal review requirement (myReview + CI passing) unchanged. Coordinator cannot merge a PR it hasn't reviewed just because Gamma said LGTM.

**3. Fix `agent.name` → `agent.ghUser` in login matching (closes #310 partially)**
Two sites in `decideAction()` used `agent.name.toLowerCase()` ("alpha"/"beta") to match GitHub login fields (which are "alpha-peer-dev"/"beta-peer-dev"):
- `myReview` find in mergeablePRs (line 810): `includes()` coincidentally worked but was fragile
- `myStaleIssues` assignee check (line 908): same pattern

Both changed to exact equality on `agent.ghUser.toLowerCase()`.

## Constraints followed

- Scoped to `gamma-peer-dev` login only (uses `AGENTS.gamma.ghUser`, not hardcoded)  
- PR review thread comments only (`pr.reviews`, not issue comments)
- Score boost not hard gate — formal review eligibility unchanged
- Approval phrases word-boundary anchored (lessons from #266)

## Note

⚠️ Requires coordinator restart to take effect after merge.