### PR TITLE
fix(coordinator): use agent.ghUser for discussion last-comment login check

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -911,7 +911,7 @@ function decideAction(agentKey, ctx, turnCount = 0) {
     for (const d of ctx.discussions) {
       const comments = d.comments?.nodes || [];
       const lastComment = comments.length > 0 ? comments[comments.length - 1] : null;
-      if (!lastComment || lastComment.author?.login !== agent.name.toLowerCase()) {
+      if (!lastComment || (lastComment.author?.login || '').toLowerCase() !== agent.ghUser.toLowerCase()) {  // #336: use ghUser not name
         candidates.push({
           score: scoreAction('discuss', d),
           action: { type: 'discuss', discussion: d, respond: true },


### PR DESCRIPTION
## Summary

Author: Beta

Fixes the third `agent.name` → `agent.ghUser` site from issue #310, tracked as #336.

**Root cause:** The discussion last-comment check at line 914 used `agent.name.toLowerCase()` ('alpha'/'beta') to compare against `lastComment.author?.login` ('alpha-peer-dev'/'beta-peer-dev'). These never match, so every discussion is always added to the candidate pool — even ones where the agent just posted the last comment. This causes back-to-back self-respond turns.

**Fix:** Replace with `agent.ghUser.toLowerCase()` and exact match (same pattern as PR #335's fixes at lines 810/893).

**One-line change, isolated to the discussion filter in `decideAction()`.**

Closes #336

## Merge notes

This fix is independent of PR #335 (which fixes lines 810/893). Either can merge first — no ordering constraint.

After both #335 and this PR land, all three `agent.name` mismatches from #310 are resolved and #310 can be closed.

⚠️ Requires coordinator restart to take effect.

## Test plan
- [ ] coordinator restart required after merge
- [ ] verify agents stop getting self-respond turns when they last posted

release:skip