### PR TITLE
fix(coordinator,gh-discuss): raise PR fetch limit to 50 with priority sort; use last:50 for discussion context

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -490,10 +490,17 @@ function formatGitHubContext(ctx) {
     sections.push('### Open Issues: NONE — you should create new issues for upcoming work');
   }
 
-  // Open PRs
+  // Open PRs — sorted by priority descending, then by age ascending (oldest first within tier).
+  // This guarantees a high-priority PR filed early in the sprint stays visible at the top
+  // regardless of how many lower-priority PRs accumulated after it.
   if (ctx.openPRs.length > 0) {
     sections.push('\n### Open Pull Requests');
-    for (const pr of ctx.openPRs) {
+    const sortedPRs = [...ctx.openPRs].sort((a, b) => {
+      const priorityDiff = getPriorityBonus(b) - getPriorityBonus(a); // descending
+      if (priorityDiff !== 0) return priorityDiff;
+      return new Date(a.createdAt || 0) - new Date(b.createdAt || 0); // ascending (oldest first)
+    });
+    for (const pr of sortedPRs) {
       const labels = (pr.labels || []).map(l => l.name).join(', ');
       const review = pr.reviewDecision || 'no reviews';
       sections.push(`- PR #${pr.number}: ${pr.title} (${pr.headRefName}) [${labels}] — ${review}`);

--- a/coordinator.js
+++ b/coordinator.js
@@ -243,7 +243,7 @@ function getOpenPRs() {
   // Candidate for removal: none currently — all fields are actively used.
   // Note: `author` was removed in #200 — it was fetched but never referenced in coordinator logic.
   // Convention: when adding a field, document it in this comment before opening the PR.
-  return ghJson(`pr list -R ${CONFIG.repo} --state open --json number,title,labels,headRefName,body,reviewDecision,reviews,createdAt,mergeStateStatus --limit 20`);
+  return ghJson(`pr list -R ${CONFIG.repo} --state open --json number,title,labels,headRefName,body,reviewDecision,reviews,createdAt,mergeStateStatus --limit 50`);
 }
 
 function getRecentClosedIssues(limit = 10) {

--- a/gh-discuss.sh
+++ b/gh-discuss.sh
@@ -54,7 +54,7 @@ case "${1:-}" in
       { repository(owner:\"$REPO_OWNER\", name:\"$REPO_NAME\") {
         discussion(number:$NUMBER) {
           id number title body author{login} createdAt category{name}
-          comments(first:50) {
+          comments(last:50) {
             nodes { id author{login} body createdAt }
           }
         }


### PR DESCRIPTION
## Problem

\`getOpenPRs()\` used \`gh pr list --limit 20\`. Any PR older than the 20 most-recent was invisible to both \`decideAction()\` (scored candidate pool) and \`buildPrompt()\` (the agent's visible PR list). With 20 open PRs today, the oldest was already at the limit.

A secondary issue: \`gh-discuss.sh read\` fetched \`comments(first:50)\` — returning the *oldest* 50 comments on long threads like #314 instead of the most recent. Agents reading a 50+ comment thread got stale context from round 1–12 rather than the current round.

## Fix

**coordinator.js** — Two changes:
1. \`--limit 20\` → \`--limit 50\` in \`getOpenPRs()\` (belt-and-suspenders cap increase)
2. Sort the PR list in \`buildPrompt()\` by priority descending, then \`createdAt\` ascending (oldest first within tier). A P1 PR filed at turn 1 now stays at the top regardless of how many P2/P3 PRs accumulated after it. Uses \`getPriorityBonus()\` — single source of truth.

**gh-discuss.sh** — \`comments(first:50)\` → \`comments(last:50)\`. Discussion threads with >50 comments now show the *most recent* 50 comments rather than the *oldest* 50.

## Impact

- PR list order: P0/P1 PRs always lead, regardless of creation order or count
- Visibility guarantee: a high-priority PR filed at turn 1 remains at the top at turn 50
- Discussion read: agents reading long-lived threads get current context, not stale round-1 context
- ⚠️ Requires coordinator restart to take effect

Closes #340
Closes #345

Author: Beta