### PR TITLE
fix(tests): correct tz test — remove vacuous wait, fix double-convert, assert content

### DIFF
--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -216,17 +216,12 @@ test('CSS Specificity — calculates specificity of a selector', async ({ page }
 
 test('Time Zone — converts a time between zones', async ({ page }) => {
   await activateTab(page, 'tab-tz');
-  // Fill in current time
+  // tzNow fills in the current time AND calls convert() internally (tools/tz.js line ~195).
+  // Result is already rendered after this click — no need to click #tzConvert separately.
   await page.click('#tzNow');
-  // Wait for zone selects to populate and select a default zone.
-  // Note: Intl.supportedValuesOf('timeZone') is synchronous, so this resolves
-  // instantly in practice. The wait documents intent and guards against future
-  // refactors to async zone loading. CI runner timezone (typically UTC or
-  // America/New_York on ubuntu-latest) is a valid IANA name — no fallback needed.
-  await expect(page.locator('#tzFrom option').first()).toBeVisible({ timeout: OUTPUT_TIMEOUT });
-  await page.click('#tzConvert');
-  // Result panel should be visible after conversion
-  await expect(page.locator('#tzResult')).toBeVisible({ timeout: OUTPUT_TIMEOUT });
+  // Assert the result contains a time string (HH:MM format).
+  // Intl.supportedValuesOf('timeZone') is synchronous so no async wait is needed.
+  await expect(page.locator('.tz-result__value')).toHaveText(/\d{1,2}:\d{2}/);
 });
 
 // ─── Diff ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #258

Author: Alpha

## What

Three fixes to the Time Zone smoke test (`tests/smoke.spec.js`):

1. **Remove vacuous `#tzFrom option` wait** — `Intl.supportedValuesOf('timeZone')` is synchronous. The wait and its comment ("guards against future refactors to async zone loading") implied async behavior that doesn't exist. A wait that always resolves instantly provides no protection.

2. **Remove redundant `#tzConvert` click** — `tzNow`'s click handler already calls `convert()` internally (`tools/tz.js` ~line 195). The old test clicked `#tzNow`, waited for zone options, then clicked `#tzConvert` — testing the second `convert()` call while the first (the actual `tzNow` behavior) was never verified. The test passed vacuously regardless of whether `tzNow` produced output.

3. **Upgrade result assertion from visibility to content** — `toBeVisible` on `#tzResult` passes as long as the element exists in the DOM. Now asserts `.tz-result__value` matches `/\d{1,2}:\d{2}/` — if `convert()` runs but produces empty or malformed output, the test fails.

## Test plan

- [ ] CI passes (Playwright smoke suite)
- [ ] Time Zone test asserts actual conversion output
- [ ] No regression on other tests