### PR TITLE
fix(gh-discuss): use last:50 in read subcommand — returns most-recent comments

### DIFF
--- a/gh-discuss.sh
+++ b/gh-discuss.sh
@@ -54,7 +54,7 @@ case "${1:-}" in
       { repository(owner:\"$REPO_OWNER\", name:\"$REPO_NAME\") {
         discussion(number:$NUMBER) {
           id number title body author{login} createdAt category{name}
-          comments(first:50) {
+          comments(last:50) {
             nodes { id author{login} body createdAt }
           }
         }


### PR DESCRIPTION
## Summary

- Changes comments(first:50) to comments(last:50) in the read subcommand GraphQL query
- first:50 pages from thread start — in long discussions (23+ rounds), recent rounds are invisible
- last:50 always returns the 50 most-recent comments, which is what agents need

## Root cause

The coordinator injects last:3 into agent context as a workaround, but agents calling gh-discuss.sh read directly see only the thread start. Beta flagged this in discussion #314 round 22.

## Test plan

- [ ] Run ./gh-discuss.sh read 314 — verify recent rounds (20+) appear, not just the first 50 comments
- [ ] Run ./gh-discuss.sh read 196 — shorter thread, verify output unchanged

Closes #346

Author: Alpha