### PR TITLE
fix(tools): remove local copyText() in base.js and regex.js — use shared utils

### DIFF
--- a/tools/base.js
+++ b/tools/base.js
@@ -2,6 +2,8 @@
 // Converts integers between binary (2), octal (8), decimal (10), and hex (16).
 // Editing any field updates the other three live.
 
+import { copyText } from './utils.js';
+
 const binInput   = document.getElementById('baseInputBin');
 const octInput   = document.getElementById('baseInputOct');
 const decInput   = document.getElementById('baseInputDec');
@@ -139,22 +141,6 @@ function onInput(sourceEl, base, label) {
 
   fill(value, sourceEl);
   setStatus('', '');
-}
-
-// ---------------------------------------------------------------------------
-// Copy helper
-// ---------------------------------------------------------------------------
-function copyText(text, btn) {
-  if (!text) return;
-  navigator.clipboard.writeText(text).then(() => {
-    const orig = btn.textContent;
-    btn.textContent = 'Copied!';
-    setTimeout(() => { btn.textContent = orig; }, 1500);
-  }).catch(() => {
-    const orig = btn.textContent;
-    btn.textContent = 'Failed!';
-    setTimeout(() => { btn.textContent = orig; }, 1500);
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/regex.js
+++ b/tools/regex.js
@@ -1,6 +1,6 @@
 // Regex Tester
 
-import { escapeHtml } from './utils.js';
+import { escapeHtml, copyText } from './utils.js';
 
 const regexPattern         = document.getElementById('regexPattern');
 const regexFlags           = document.getElementById('regexFlags');
@@ -164,8 +164,5 @@ regexReplaceTemplate.addEventListener('input', scheduleRegex);
 
 regexReplaceCopy.addEventListener('click', () => {
   if (!regexReplaceOutput.value) return;
-  navigator.clipboard.writeText(regexReplaceOutput.value).then(() => {
-    regexReplaceCopy.textContent = 'Copied!';
-    setTimeout(() => { regexReplaceCopy.textContent = 'Copy'; }, 1500);
-  });
+  copyText(regexReplaceOutput.value, regexReplaceCopy);
 });


### PR DESCRIPTION
## Problem

Two tools re-implement clipboard logic instead of using the shared `copyText` from `utils.js`:

**base.js (#278)** — defines its own `copyText(text, btn)` (lines 147-158). The local version shows 'Failed!' on error but doesn't use the `btn--success` visual class. The shared utils.js version handles both cases and is strictly better.

**regex.js (#285)** — the replace-mode copy button had an inline `navigator.clipboard.writeText().then()` with no `.catch()`. Silent failure on clipboard permission deny.

## Fix

**base.js** — Add `import { copyText } from './utils.js'` at top. Remove the 18-line local `copyText` definition. All three call sites use the same signature — no call-site changes needed.

**regex.js** — Add `copyText` to the existing import from utils.js. Replace the 6-line inline handler with `copyText(regexReplaceOutput.value, regexReplaceCopy)`. The early-return guard is preserved.

## Why batched

Both fixes are in different files with no shared state and no ordering dependency. Batching reduces PR lifecycle overhead (one CI run, one review cycle) for two independent fixes.

Closes #278, Closes #285

Author: Alpha