### PR TITLE
fix(coordinator): throttle new PR creation when approved-unmerged backlog exceeds threshold

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -884,8 +884,12 @@ function decideAction(agentKey, ctx, turnCount = 0) {
   //
   // NOTE: pr.reviewDecision is only populated when branch protection enforces a minimum
   // review count — this repo has no such rule, so reviewDecision is always "". Use
-  // pr.reviews directly to detect any APPROVED formal review instead.
-  const hasFormalApproval = pr => (pr.reviews || []).some(r => r.state === 'APPROVED');
+  // pr.reviews directly, filtered to Gamma's quality-gate approval. Any-reviewer approval
+  // would count peer reviews that haven't cleared Gamma's gate — not truly merge-ready.
+  const gammaGhUser = AGENTS.gamma.ghUser.toLowerCase();
+  const hasFormalApproval = pr => (pr.reviews || []).some(
+    r => r.state === 'APPROVED' && (r.author?.login || '').toLowerCase() === gammaGhUser
+  );
   const approvedUnmergedCount = ctx.openPRs.filter(pr =>
     hasFormalApproval(pr) && pr.mergeStateStatus !== 'CONFLICTING'
   ).length;

--- a/coordinator.js
+++ b/coordinator.js
@@ -881,8 +881,13 @@ function decideAction(agentKey, ctx, turnCount = 0) {
   // When the backlog is large, pause new implement-issue actions (except P0/P1) so the
   // queue drains faster than it grows. P0/P1 fixes bypass the gate — security and
   // critical bugs shouldn't wait for the operator's merge session.
+  //
+  // NOTE: pr.reviewDecision is only populated when branch protection enforces a minimum
+  // review count — this repo has no such rule, so reviewDecision is always "". Use
+  // pr.reviews directly to detect any APPROVED formal review instead.
+  const hasFormalApproval = pr => (pr.reviews || []).some(r => r.state === 'APPROVED');
   const approvedUnmergedCount = ctx.openPRs.filter(pr =>
-    pr.reviewDecision === 'APPROVED' && pr.mergeStateStatus !== 'CONFLICTING'
+    hasFormalApproval(pr) && pr.mergeStateStatus !== 'CONFLICTING'
   ).length;
   if (approvedUnmergedCount >= APPROVED_UNMERGED_THRESHOLD) {
     log(`[${agent.name}] ⚠ Throttle: ${approvedUnmergedCount} approved-unmerged PRs (threshold: ${APPROVED_UNMERGED_THRESHOLD}) — skipping new implement-issue actions for P2+`);

--- a/coordinator.js
+++ b/coordinator.js
@@ -558,6 +558,9 @@ function formatGitHubContext(ctx) {
 // ─── Reflection thresholds ─────────────────────────────────────────────────
 const CHECKPOINT_WORK_THRESHOLD  = 12;
 const SELF_REFLECT_WORK_THRESHOLD = 5;
+// When this many approved-but-unmerged PRs sit in the queue, pause new implement-issue
+// actions (except P0/P1) to avoid growing the backlog faster than it can drain.
+const APPROVED_UNMERGED_THRESHOLD = 15;
 let workSinceCheckpoint = 0;
 const workSinceReflect = { alpha: 0, beta: 0, gamma: 0 };
 const PRODUCTIVE_ACTIONS = new Set(['implement-issue', 'merge-pr', 'resolve-conflict']);
@@ -874,12 +877,30 @@ function decideAction(agentKey, ctx, turnCount = 0) {
     // Stale peer PRs are already captured as review candidates with stale bonus above
   }
 
+  // ── Throttle check: count approved-but-unmerged PRs
+  // When the backlog is large, pause new implement-issue actions (except P0/P1) so the
+  // queue drains faster than it grows. P0/P1 fixes bypass the gate — security and
+  // critical bugs shouldn't wait for the operator's merge session.
+  const approvedUnmergedCount = ctx.openPRs.filter(pr =>
+    pr.reviewDecision === 'APPROVED' && pr.mergeStateStatus !== 'CONFLICTING'
+  ).length;
+  if (approvedUnmergedCount >= APPROVED_UNMERGED_THRESHOLD) {
+    log(`[${agent.name}] ⚠ Throttle: ${approvedUnmergedCount} approved-unmerged PRs (threshold: ${APPROVED_UNMERGED_THRESHOLD}) — skipping new implement-issue actions for P2+`);
+  }
+
   // ── Implement unassigned issues
   const unassigned = ctx.openIssues.filter(i =>
     (i.assignees || []).length === 0 &&
     !(i.labels || []).some(l => l.name === 'status:blocked')
   );
   for (const issue of unassigned) {
+    // Throttle: skip P2+ issues when approved-unmerged backlog is too large
+    if (approvedUnmergedCount >= APPROVED_UNMERGED_THRESHOLD) {
+      const isHighPriority = (issue.labels || []).some(l =>
+        l.name === 'P0-critical' || l.name === 'P1-high'
+      );
+      if (!isHighPriority) continue;
+    }
     candidates.push({
       score: scoreAction('implement-issue', issue),
       action: { type: 'implement-issue', issue },
@@ -899,6 +920,13 @@ function decideAction(agentKey, ctx, turnCount = 0) {
     return !hasPR;
   });
   for (const issue of myStaleIssues) {
+    // Throttle: skip P2+ issues when approved-unmerged backlog is too large
+    if (approvedUnmergedCount >= APPROVED_UNMERGED_THRESHOLD) {
+      const isHighPriority = (issue.labels || []).some(l =>
+        l.name === 'P0-critical' || l.name === 'P1-high'
+      );
+      if (!isHighPriority) continue;
+    }
     candidates.push({
       score: scoreAction('implement-issue', issue) + 5, // small bonus for already-assigned
       action: { type: 'implement-issue', issue },


### PR DESCRIPTION
## Problem

The coordinator spawns agents who file PRs continuously regardless of how many approved-but-unmerged PRs sit in the queue. When merges lag behind PR creation, the backlog grows unboundedly — 27 open PRs as of this writing, ~20 of them approved and waiting.

## Fix

Adds `APPROVED_UNMERGED_THRESHOLD = 15` (configurable constant in coordinator.js).

When `approvedUnmergedCount >= threshold`, `decideAction()` skips new `implement-issue` candidates for P2+ issues. P0/P1 issues bypass the gate — security and critical bugs should not wait for the operator's merge session.

The gate applies to both:
- Unassigned issues picked up opportunistically
- Stale assigned issues resumed by the agent

A ⚠ warning is logged at the throttle decision point for observability.

## Why APPROVED only (not all open PRs)

Throttling on total open PRs would suppress new PRs even when reviews are in-flight. The right signal is "approved but not merged" — that's work the operator can drain in one session. CHANGES_REQUESTED PRs represent active work and shouldn't count against the threshold.

## Threshold rationale

15 is conservative. At 15+ approved-unmerged PRs, the merge session is already sizeable. The current queue (20+) would already trigger throttling — if this had been in place two sprints ago, we wouldn't have reached this state.

Closes #348

Author: Alpha

⚠ Requires coordinator restart to take effect.