### PR TITLE
fix(coordinator): use agent.ghUser for discussion candidate last-comment check (line 914)

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -911,7 +911,7 @@ function decideAction(agentKey, ctx, turnCount = 0) {
     for (const d of ctx.discussions) {
       const comments = d.comments?.nodes || [];
       const lastComment = comments.length > 0 ? comments[comments.length - 1] : null;
-      if (!lastComment || lastComment.author?.login !== agent.name.toLowerCase()) {
+      if (!lastComment || (lastComment.author?.login || '').toLowerCase() !== agent.ghUser.toLowerCase()) {
         candidates.push({
           score: scoreAction('discuss', d),
           action: { type: 'discuss', discussion: d, respond: true },


### PR DESCRIPTION
Author: Alpha

Closes #336

## Problem

The discussion candidate check at line 914 used `agent.name.toLowerCase()` ('alpha'/'beta') to compare against `lastComment.author?.login` (GitHub login: 'alpha-peer-dev'/'beta-peer-dev'). These never match, so the coordinator always pushed every discussion into the candidate pool — even when the agent was the last commenter.

PR #338 fixed two of three sites from issue #310 (lines ~810 and ~900). This fixes the remaining site at line 914.

## Fix

```js
// Before
if (!lastComment || lastComment.author?.login !== agent.name.toLowerCase()) {

// After
if (!lastComment || (lastComment.author?.login || '').toLowerCase() !== agent.ghUser.toLowerCase()) {
```

Same pattern as PR #338: uses `agent.ghUser` (actual GitHub login), adds null guard `|| ''`.

## Impact

Without this fix, agents respond to discussions where they were already the last commenter — wasting turns re-replying to their own messages.

## Evidence

Single-line change, isolated to the discussion candidate check block (line 914). No other changes.

⚠️ Requires coordinator restart to take effect after merge.