### PR TITLE
fix(semver): replace unsafe integer subtraction with explicit comparison

### DIFF
--- a/tools/semver.js
+++ b/tools/semver.js
@@ -130,8 +130,10 @@ function comparePrerelease(a, b) {
     const bNum = /^\d+$/.test(bId);
 
     if (aNum && bNum) {
-      const diff = parseInt(aId, 10) - parseInt(bId, 10);
-      if (diff !== 0) return diff;
+      // Use explicit comparison — subtraction is unsafe for integers above 2^53
+      const aInt = parseInt(aId, 10), bInt = parseInt(bId, 10);
+      if (aInt < bInt) return -1;
+      if (aInt > bInt) return 1;
     } else if (aNum) {
       return -1; // numeric < alphanumeric
     } else if (bNum) {
@@ -145,9 +147,9 @@ function comparePrerelease(a, b) {
 }
 
 function compareSemver(a, b) {
-  if (a.major !== b.major) return a.major - b.major;
-  if (a.minor !== b.minor) return a.minor - b.minor;
-  if (a.patch !== b.patch) return a.patch - b.patch;
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
   return comparePrerelease(a.prerelease, b.prerelease);
 }
 


### PR DESCRIPTION
## Problem

`comparePrerelease` in `tools/semver.js` used integer subtraction to compare numeric pre-release identifiers:

```js
const diff = parseInt(aId, 10) - parseInt(bId, 10);
if (diff !== 0) return diff;
```

For identifiers above 2^53, `parseInt` returns approximate IEEE 754 values and the subtraction can produce incorrect `diff === 0` for distinct values — yielding a wrong ordering result. The semver spec (§11) places no cap on numeric identifier magnitude.

The same pattern was in `compareSemver` for major/minor/patch comparisons.

## Fix

Replace subtraction with explicit `<`/`>` comparison in both functions:

```js
// comparePrerelease
const aInt = parseInt(aId, 10), bInt = parseInt(bId, 10);
if (aInt < bInt) return -1;
if (aInt > bInt) return 1;

// compareSemver
if (a.major !== b.major) return a.major < b.major ? -1 : 1;
```

**Note:** The local `escHtml` duplicate (second issue in #283) is already resolved — PR #325 replaced it with the shared import from `utils.js`. The import on line 4 confirms this.

## Changes

- `tools/semver.js` — 2 functions, 7 net line delta

Closes #283

Author: Beta