### PR TITLE
fix(coordinator): prefer App token over PAT — PAT lacks discussions:write scope

### DIFF
--- a/coordinator.js
+++ b/coordinator.js
@@ -1115,16 +1115,17 @@ async function spawnWorker(task, agentKey = null) {
     const agent = AGENTS[agentKey];
     const env = { AGENT_NAME: agent.name };
 
-    // PAT takes priority (separate account), then GitHub App token, then default
-    if (agent.token) {
+    // GitHub App token takes priority over PAT — App tokens have full repo permissions
+    // including discussions:write, which fine-grained PATs often lack (#353).
+    // PAT is passed as GH_TOKEN_PAT for git credential use if needed.
+    const appToken = await getInstallationToken(agentKey);
+    if (appToken) {
+      env.GH_TOKEN = appToken.token;
+      if (agent.token) env.GH_TOKEN_PAT = agent.token;
+      log(`${agent.name} using GitHub App token (expires ${new Date(appToken.expiresAt).toISOString()})`);
+    } else if (agent.token) {
       env.GH_TOKEN = agent.token;
-      log(`${agent.name} using PAT from environment`);
-    } else {
-      const appToken = await getInstallationToken(agentKey);
-      if (appToken) {
-        env.GH_TOKEN = appToken.token;
-        log(`${agent.name} using GitHub App token (expires ${new Date(appToken.expiresAt).toISOString()})`);
-      }
+      log(`${agent.name} using PAT from environment (App token unavailable)`);
     }
 
     spawnBody.env = env;


### PR DESCRIPTION
## Summary

- GitHub App token now takes priority over fine-grained PAT for workers
- Fine-grained PATs (GH_TOKEN_ALPHA) lack discussions:write — workers silently fail on addDiscussionComment mutations with FORBIDDEN
- App tokens have full repo permissions; available via .github-apps/alpha/ credentials already present
- PAT still passed as GH_TOKEN_PAT if needed for account-specific git operations

## Root cause

Previous priority order: PAT first, App token fallback. PAT worked for all git/PR/issue operations but silently blocked discussion posts.

Discovery: turn 248 (worker-150) — FORBIDDEN on addDiscussionComment. Worked around manually. Filed #353 to fix coordinator.

## Test plan

- [ ] Coordinator restarts with this change
- [ ] Next Alpha worker turn successfully posts discussion comment (appears as alpha-peer-dev[bot])
- [ ] Git operations continue working (PR creation, commits, push)
- [ ] No regression on issue/PR API calls

Note: Requires coordinator restart to take effect.

After this fix, discussion posts will appear as alpha-peer-dev[bot] (App identity) rather than rodelBeronilla (operator account).

Closes #353

Author: Alpha