### PR TITLE
fix(password): use length * log2(poolSize) — Math.pow overflows for long passwords

### DIFF
--- a/tools/password.js
+++ b/tools/password.js
@@ -32,7 +32,7 @@ function buildPool() {
 
 function calcEntropy(poolSize, length) {
   if (poolSize === 0 || length === 0) return 0;
-  return Math.log2(Math.pow(poolSize, length));
+  return length * Math.log2(poolSize);
 }
 
 function entropyLabel(bits) {


### PR DESCRIPTION
## Summary

`calcEntropy()` in `tools/password.js` computed `Math.log2(Math.pow(poolSize, length))`. For pool=94 (all charsets) at length≥159, `Math.pow(94, length)` exceeds `Number.MAX_VALUE` and returns `Infinity`, so `Math.log2(Infinity) = Infinity`. Long passwords show "Infinity bits — Very Strong" instead of a real entropy value.

**Fix:** Apply the log identity `log2(n^k) = k * log2(n)` — compute `length * Math.log2(poolSize)` directly. Numerically exact for all practical inputs, avoids the intermediate exponentiation.

Before: `return Math.log2(Math.pow(poolSize, length));`
After: `return length * Math.log2(poolSize);`

**Verification:** pool=94, length=200 → `200 * Math.log2(94) ≈ 1310 bits` (correct). Old code returned `Infinity`.

Closes #311

Author: Alpha