### PR TITLE
fix(gh-discuss): log non-200 API responses and GraphQL error payloads

### DIFF
--- a/gh-discuss.sh
+++ b/gh-discuss.sh
@@ -73,13 +73,19 @@ case "${1:-}" in
     # Escape for JSON
     BODY_ESCAPED="$(echo "$BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])' 2>/dev/null || echo "$BODY" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d).slice(1,-1)))" 2>/dev/null || echo "$BODY" | sed 's/\\/\\\\/g; s/"/\\"/g')"
     TITLE_ESCAPED="$(echo "$TITLE" | sed 's/"/\\"/g')"
-    gh api graphql -f query="
+    RESULT="$(gh api graphql -f query="
       mutation { createDiscussion(input: {
         repositoryId: \"$REPO_ID\",
         categoryId: \"$CATEGORY_ID\",
         title: \"$TITLE_ESCAPED\",
         body: \"$BODY_ESCAPED\"
-      }) { discussion { number url } } }"
+      }) { discussion { number url } } }" 2>&1)" || { echo "ERROR: gh api graphql exited non-zero: $RESULT" >&2; exit 1; }
+    if echo "$RESULT" | python3 -c 'import json,sys; d=json.load(sys.stdin); errs=d.get("errors"); print("\n".join(e.get("message","(unknown)") for e in errs) if errs else "", end="")' 2>/dev/null | grep -q .; then
+      echo "ERROR: GitHub API returned errors:" >&2
+      echo "$RESULT" | python3 -c 'import json,sys; d=json.load(sys.stdin); [print(e.get("message","(unknown)"),file=__import__("sys").stderr) for e in d.get("errors",[])]' 2>&1 >&2 || true
+      exit 1
+    fi
+    echo "$RESULT"
     ;;
 
   comment)
@@ -95,11 +101,17 @@ case "${1:-}" in
       exit 1
     fi
     BODY_ESCAPED="$(echo "$BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])' 2>/dev/null || echo "$BODY" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d).slice(1,-1)))" 2>/dev/null || echo "$BODY" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-    gh api graphql -f query="
+    RESULT="$(gh api graphql -f query="
       mutation { addDiscussionComment(input: {
         discussionId: \"$DISC_ID\",
         body: \"$BODY_ESCAPED\"
-      }) { comment { id } } }"
+      }) { comment { id } } }" 2>&1)" || { echo "ERROR: gh api graphql exited non-zero: $RESULT" >&2; exit 1; }
+    if echo "$RESULT" | python3 -c 'import json,sys; d=json.load(sys.stdin); errs=d.get("errors"); print("\n".join(e.get("message","(unknown)") for e in errs) if errs else "", end="")' 2>/dev/null | grep -q .; then
+      echo "ERROR: GitHub API returned errors:" >&2
+      echo "$RESULT" | python3 -c 'import json,sys; d=json.load(sys.stdin); [print(e.get("message","(unknown)"),file=__import__("sys").stderr) for e in d.get("errors",[])]' 2>&1 >&2 || true
+      exit 1
+    fi
+    echo "$RESULT"
     ;;
 
   *)


### PR DESCRIPTION
## Summary

`create` and `comment` subcommands in `gh-discuss.sh` discarded all output from `gh api graphql` mutations. When the token lacked `discussions:write` scope, the API returned a 200 OK response with a JSON `errors` array — the script exited 0 and showed nothing. Silent failure.

**Fix:**
- Capture mutation output into `$RESULT`
- On non-zero exit from `gh api`, print the output to stderr and exit 1
- Parse `$RESULT` JSON for an `errors` array; if present, print each `message` to stderr and exit 1
- On success, echo `$RESULT` as before

Both `create` and `comment` paths are patched identically.

Closes #362

Author: Alpha