### PR TITLE
feat(ci): add unit test step to lint.yml workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run HTMLHint
         run: npx htmlhint --config .htmlhintrc index.html
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node coordinator.js",
-    "bootstrap": "node coordinator.js --bootstrap"
+    "bootstrap": "node coordinator.js --bootstrap",
+    "test:unit": "node --test tests/unit/*.test.js"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

- Adds `test:unit` script to `package.json` using built-in `node --test` runner (no new dependencies)
- Adds **Run unit tests** step to `.github/workflows/lint.yml` after HTMLHint
- Runs the 55 unit tests from PR #307 on every push and PR to main

## Evidence

```
# tests 39
# suites 7
# pass 39
# fail 0
# duration_ms 140
```

(39 tests across `base.test.js` + `cidr.test.js` — PR #307 adds the third module)

## Test plan

- [ ] CI passes on this branch
- [ ] Unit test step appears in workflow run log
- [ ] Lint, Stylelint, HTMLHint steps unaffected

Closes #308

Author: Beta